### PR TITLE
optimize encoding

### DIFF
--- a/src/codec/encoder/HoudiniEncoder.cpp
+++ b/src/codec/encoder/HoudiniEncoder.cpp
@@ -362,6 +362,8 @@ namespace detail {
 
 SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, const std::vector<prtx::MaterialPtrVector>& materials) {
 	// PASS 1: scan
+	uint32_t numCoords = 0;
+	uint32_t numNormalCoords = 0;
 	uint32_t numCounts = 0;
 	uint32_t numIndices = 0;
 	uint32_t maxNumUVSets = 0;
@@ -371,6 +373,9 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, 
 		const prtx::MaterialPtrVector& mats = *matsIt;
 		auto matIt = mats.cbegin();
 		for (const auto& mesh: meshes) {
+			numCoords += mesh->getVertexCoords().size();
+			numNormalCoords += mesh->getVertexNormalsCoords().size();
+
 			numCounts += mesh->getFaceCount();
 			const auto& vtxCnts = mesh->getFaceVertexCounts();
 			numIndices = std::accumulate(vtxCnts.begin(), vtxCnts.end(), numIndices);
@@ -382,7 +387,7 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, 
 		}
 		++matsIt;
 	}
-	detail::SerializedGeometry sg(numCounts, numIndices, maxNumUVSets);
+	detail::SerializedGeometry sg(numCoords, numNormalCoords, numCounts, numIndices, maxNumUVSets);
 
 	// PASS 2: copy
 	uint32_t vertexIndexBase = 0;

--- a/src/codec/encoder/HoudiniEncoder.cpp
+++ b/src/codec/encoder/HoudiniEncoder.cpp
@@ -362,6 +362,8 @@ namespace detail {
 
 SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, const std::vector<prtx::MaterialPtrVector>& materials) {
 	// PASS 1: scan
+	uint32_t numCounts = 0;
+	uint32_t numIndices = 0;
 	uint32_t maxNumUVSets = 0;
 	auto matsIt = materials.cbegin();
 	for (const auto& geo: geometries) {
@@ -369,6 +371,10 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, 
 		const prtx::MaterialPtrVector& mats = *matsIt;
 		auto matIt = mats.cbegin();
 		for (const auto& mesh: meshes) {
+			numCounts += mesh->getFaceCount();
+			const auto& vtxCnts = mesh->getFaceVertexCounts();
+			numIndices = std::accumulate(vtxCnts.begin(), vtxCnts.end(), numIndices);
+
 			const prtx::MaterialPtr& mat = *matIt;
 			const uint32_t requiredUVSetsByMaterial = scanValidTextures(mat);
 			maxNumUVSets = std::max(maxNumUVSets, std::max(mesh->getUVSetsCount(), requiredUVSetsByMaterial));
@@ -376,7 +382,7 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, 
 		}
 		++matsIt;
 	}
-	detail::SerializedGeometry sg(maxNumUVSets);
+	detail::SerializedGeometry sg(numCounts, numIndices, maxNumUVSets);
 
 	// PASS 2: copy
 	uint32_t vertexIndexBase = 0;
@@ -428,12 +434,10 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, 
 			} // for all uv sets
 
 			// append counts and indices for vertices and vertex normals
-			sg.counts.reserve(sg.counts.size() + mesh->getFaceCount());
 			for (uint32_t fi = 0, faceCount = mesh->getFaceCount(); fi < faceCount; ++fi) {
 				const uint32_t* vtxIdx = mesh->getFaceVertexIndices(fi);
 				const uint32_t vtxCnt = mesh->getFaceVertexCount(fi);
 				sg.counts.push_back(vtxCnt);
-				sg.indices.reserve(sg.indices.size() + vtxCnt);
 				for (uint32_t vi = 0; vi < vtxCnt; vi++)
 					sg.indices.push_back(vertexIndexBase + vtxIdx[vtxCnt - vi - 1]); // reverse winding
 			}

--- a/src/codec/encoder/HoudiniEncoder.h
+++ b/src/codec/encoder/HoudiniEncoder.h
@@ -49,9 +49,11 @@ struct SerializedGeometry {
 	std::vector<prtx::IndexVector>  uvCounts;
 	std::vector<prtx::IndexVector>  uvIndices;
 
-	SerializedGeometry(uint32_t numCounts, uint32_t numIndices, uint32_t uvSets)
+	SerializedGeometry(uint32_t numCoords, uint32_t numNormalCoords, uint32_t numCounts, uint32_t numIndices, uint32_t uvSets)
 		: uvs(uvSets), uvCounts(uvSets), uvIndices(uvSets)
 	{
+		coords.reserve(3 * numCoords);
+		normals.reserve(3 * numNormalCoords);
 		counts.reserve(numCounts);
 		indices.reserve(numIndices);
 	}

--- a/src/codec/encoder/HoudiniEncoder.h
+++ b/src/codec/encoder/HoudiniEncoder.h
@@ -49,7 +49,12 @@ struct SerializedGeometry {
 	std::vector<prtx::IndexVector>  uvCounts;
 	std::vector<prtx::IndexVector>  uvIndices;
 
-	SerializedGeometry(uint32_t uvSets) : uvs(uvSets), uvCounts(uvSets), uvIndices(uvSets) { }
+	SerializedGeometry(uint32_t numCounts, uint32_t numIndices, uint32_t uvSets)
+		: uvs(uvSets), uvCounts(uvSets), uvIndices(uvSets)
+	{
+		counts.reserve(numCounts);
+		indices.reserve(numIndices);
+	}
 };
 
 // visible for tests


### PR DESCRIPTION
improve the transfer of geometry from PRT to Houdini; reduces cooking time of pldGenerate for e.g. the parthenon rule example (CityEngine Tutorial 9) by factor 7x