### PR TITLE
Update to PRT 2.2 and basic array attribute support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,17 @@
+BasedOnStyle: LLVM
+
+AccessModifierOffset: -4
+AllowShortFunctionsOnASingleLine: Empty
+AlwaysBreakTemplateDeclarations: Yes
+BraceWrapping:
+  BeforeCatch: true
+  BeforeElse: true
+BreakBeforeBraces: Custom
+ColumnLimit: 120
+ContinuationIndentWidth: 8
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth: 4
+PointerAlignment: Left
+TabWidth: 4
+UseTab: ForIndentation

--- a/conan/cesdk/conanfile.py
+++ b/conan/cesdk/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile
 from conans import tools
-
+from conans.model.version import Version
 
 class CESDKConan(ConanFile):
     name = "cesdk"
@@ -12,7 +12,8 @@ class CESDKConan(ConanFile):
 
     def build(self):
         if self.settings.os == "Windows":
-            url = self.baseURL.format(self.version, self.version, "win10", "vc141")
+            toolchain = "vc142" if self.version >= Version("2.2.6332") else "vc141"
+            url = self.baseURL.format(self.version, self.version, "win10", toolchain)
         elif self.settings.os == "Linux":
             url = self.baseURL.format(self.version, self.version, "rhel7", "gcc63")
         elif self.settings.os == "Macos":

--- a/conan/houdini/conanfile.py
+++ b/conan/houdini/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile
+from conans.model.version import Version
 import os
 
 class HoudiniConan(ConanFile):
@@ -38,3 +39,10 @@ class HoudiniConan(ConanFile):
         self.cpp_info.libdirs = ['dsolib']
         self.cpp_info.libs = ['HoudiniUI', 'HoudiniOPZ', 'HoudiniOP3', 'HoudiniOP2',
                               'HoudiniOP1', 'HoudiniGEO', 'HoudiniPRM', 'HoudiniUT']
+
+    def package_id(self):
+        v = Version(str(self.settings.compiler.version))
+        if self.settings.compiler == "Visual Studio" and ("15" <= v <= "16"):
+            self.info.settings.compiler.version = "Compatible with MSVC 14.1 and 14.2"
+        elif self.settings.compiler == "gcc" and ("6" <= v < "9"):
+            self.info.settings.compiler.version = "Compatible with GCC 6 tru 8"

--- a/conan/profiles/windows-v142
+++ b/conan/profiles/windows-v142
@@ -1,0 +1,15 @@
+[settings]
+os=Windows
+os_build=Windows
+arch=x86_64
+arch_build=x86_64
+build_type=Release
+compiler=Visual Studio
+compiler.version=16
+compiler.runtime=MD
+
+[options]
+
+[build_requires]
+
+[env]

--- a/pipeline.groovy
+++ b/pipeline.groovy
@@ -17,11 +17,6 @@ import com.esri.zrh.jenkins.ce.PrtAppPipelineLibrary
 @Field final String SOURCE       = "palladio.git/src"
 @Field final String BUILD_TARGET = 'package'
 
-@Field final List CONFIGS_HOUDINI_170 = [
-	[ os: cepl.CFG_OS_RHEL7, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_GCC63, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '17.0' ],
-	[ os: cepl.CFG_OS_WIN10, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_VC142, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '17.0' ],
-]
-
 @Field final List CONFIGS_HOUDINI_175 = [
 	[ os: cepl.CFG_OS_RHEL7, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_GCC63, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '17.5' ],
 	[ os: cepl.CFG_OS_WIN10, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_VC142, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '17.5' ],
@@ -57,7 +52,6 @@ Map getTasks(String branchName = null) {
 Map taskGenPalladio() {
     Map tasks = [:]
     // FIXME: this is a workaround to get unique task names
-	tasks << cepl.generateTasks('pld-hdn17.0', this.&taskBuildPalladio, CONFIGS_HOUDINI_170)
 	tasks << cepl.generateTasks('pld-hdn17.5', this.&taskBuildPalladio, CONFIGS_HOUDINI_175)
 	tasks << cepl.generateTasks('pld-hdn18.0', this.&taskBuildPalladio, CONFIGS_HOUDINI_180)
 	return tasks;

--- a/pipeline.groovy
+++ b/pipeline.groovy
@@ -19,17 +19,17 @@ import com.esri.zrh.jenkins.ce.PrtAppPipelineLibrary
 
 @Field final List CONFIGS_HOUDINI_170 = [
 	[ os: cepl.CFG_OS_RHEL7, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_GCC63, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '17.0' ],
-	[ os: cepl.CFG_OS_WIN10, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_VC141, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '17.0' ],
+	[ os: cepl.CFG_OS_WIN10, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_VC142, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '17.0' ],
 ]
 
 @Field final List CONFIGS_HOUDINI_175 = [
 	[ os: cepl.CFG_OS_RHEL7, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_GCC63, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '17.5' ],
-	[ os: cepl.CFG_OS_WIN10, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_VC141, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '17.5' ],
+	[ os: cepl.CFG_OS_WIN10, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_VC142, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '17.5' ],
 ]
 
 @Field final List CONFIGS_HOUDINI_180 = [
 	[ os: cepl.CFG_OS_RHEL7, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_GCC63, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '18.0' ],
-	[ os: cepl.CFG_OS_WIN10, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_VC141, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '18.0' ],
+	[ os: cepl.CFG_OS_WIN10, bc: cepl.CFG_BC_REL, tc: cepl.CFG_TC_VC142, cc: cepl.CFG_CC_OPT, arch: cepl.CFG_ARCH_X86_64, houdini: '18.0' ],
 ]
 
 // -- PIPELINE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,15 @@ set(PLD_VERSION "${PLD_VERSION_MAJOR}.${PLD_VERSION_MINOR}.${PLD_VERSION_PATCH}$
 .prt${PRT_VERSION_MAJOR}-${PRT_VERSION_MINOR}-${PRT_VERSION_MICRO}")
 message(STATUS "Using PLD_VERSION = ${PLD_VERSION}")
 
+function(pld_add_version_definitions TGT)
+	target_compile_definitions(${TGT} PRIVATE
+			-DPLD_VERSION_MAJOR=${PLD_VERSION_MAJOR}
+			-DPLD_VERSION_MINOR=${PLD_VERSION_MINOR}
+			-DPLD_VERSION_PATCH=${PLD_VERSION_PATCH}
+			-DPLD_VERSION_PRE=\"${PLD_VERSION_PRE}\" # quoted, might be a string
+			-DPLD_VERSION_BUILD=${PLD_VERSION_BUILD}
+			-DPLD_VERSION=\"${PLD_VERSION}\") # quoted, is a string
+endfunction()
 
 ### setup installation target
 

--- a/src/codec/CodecMain.cpp
+++ b/src/codec/CodecMain.cpp
@@ -18,35 +18,27 @@
 
 #include "encoder/HoudiniEncoder.h"
 
-#include "prtx/prtx.h"
 #include "prtx/ExtensionManager.h"
-
+#include "prtx/prtx.h"
 
 namespace {
 const int VERSION_MAJOR = PRT_VERSION_MAJOR;
 const int VERSION_MINOR = PRT_VERSION_MINOR;
-}
+} // namespace
 
 extern "C" {
-
 
 CODEC_EXPORTS_API void registerExtensionFactories(prtx::ExtensionManager* manager) {
 	manager->addFactory(HoudiniEncoderFactory::createInstance());
 }
 
-
-CODEC_EXPORTS_API void unregisterExtensionFactories(prtx::ExtensionManager* /*manager*/) {
-}
-
+CODEC_EXPORTS_API void unregisterExtensionFactories(prtx::ExtensionManager* /*manager*/) {}
 
 CODEC_EXPORTS_API int getVersionMajor() {
 	return VERSION_MAJOR;
 }
 
-
 CODEC_EXPORTS_API int getVersionMinor() {
 	return VERSION_MINOR;
 }
-
-
 }

--- a/src/codec/CodecMain.h
+++ b/src/codec/CodecMain.h
@@ -19,5 +19,5 @@
 #ifdef _WIN32
 #	define CODEC_EXPORTS_API __declspec(dllexport)
 #else
-#	define CODEC_EXPORTS_API __attribute__ ((visibility ("default")))
+#	define CODEC_EXPORTS_API __attribute__((visibility("default")))
 #endif

--- a/src/codec/encoder/HoudiniCallbacks.h
+++ b/src/codec/encoder/HoudiniCallbacks.h
@@ -20,13 +20,11 @@
 
 constexpr const wchar_t* ENCODER_ID_HOUDINI = L"HoudiniEncoder";
 constexpr const wchar_t* EO_EMIT_ATTRIBUTES = L"emitAttributes";
-constexpr const wchar_t* EO_EMIT_MATERIALS  = L"emitMaterials";
-constexpr const wchar_t* EO_EMIT_REPORTS    = L"emitReports";
-
+constexpr const wchar_t* EO_EMIT_MATERIALS = L"emitMaterials";
+constexpr const wchar_t* EO_EMIT_REPORTS = L"emitReports";
 
 class HoudiniCallbacks : public prt::Callbacks {
 public:
-
 	virtual ~HoudiniCallbacks() override = default;
 
 	/**
@@ -47,25 +45,18 @@ public:
 	 * @param uvIndicesSizes number of uv indices per face per uv set
 	 * @param uvSets number of uv sets
 	 * @param faceRanges ranges for materials and reports
-	 * @param materials contains faceRangesSize-1 attribute maps (all materials must have an identical set of keys and types)
+	 * @param materials contains faceRangesSize-1 attribute maps (all materials must have an identical set of keys and
+	 * types)
 	 * @param reports contains faceRangesSize-1 attribute maps
 	 * @param shapeIDs shape ids per face, contains faceRangesSize-1 values
 	 */
-	virtual void add(
-			const wchar_t* name,
-			const double* vtx, size_t vtxSize,
-			const double* nrm, size_t nrmSize,
-			const uint32_t* counts, size_t countsSize,
-			const uint32_t* indices, size_t indicesSize,
+	virtual void add(const wchar_t* name, const double* vtx, size_t vtxSize, const double* nrm, size_t nrmSize,
+	                 const uint32_t* counts, size_t countsSize, const uint32_t* indices, size_t indicesSize,
 
-			double const* const* uvs, size_t const* uvsSizes,
-			uint32_t const* const* uvCounts, size_t const* uvCountsSizes,
-			uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,
-			uint32_t uvSets,
+	                 double const* const* uvs, size_t const* uvsSizes, uint32_t const* const* uvCounts,
+	                 size_t const* uvCountsSizes, uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,
+	                 uint32_t uvSets,
 
-			const uint32_t* faceRanges, size_t faceRangesSize,
-			const prt::AttributeMap** materials,
-			const prt::AttributeMap** reports,
-			const int32_t* shapeIDs
-	) = 0;
+	                 const uint32_t* faceRanges, size_t faceRangesSize, const prt::AttributeMap** materials,
+	                 const prt::AttributeMap** reports, const int32_t* shapeIDs) = 0;
 };

--- a/src/codec/encoder/HoudiniEncoder.cpp
+++ b/src/codec/encoder/HoudiniEncoder.cpp
@@ -280,19 +280,25 @@ void forwardGenericAttributes(HoudiniCallbacks* hc, size_t initialShapeIndex, co
                               const prtx::ShapePtr& shape) {
 	forEachKey(initialShape.getAttributeMap(),
 	           [&hc, &shape, &initialShapeIndex, &initialShape](prt::Attributable const* a, wchar_t const* key) {
-		           switch (shape->getType(key)) {
+		           assert(key != nullptr);
+		           const std::wstring keyStr(key);
+
+		           if (!shape->hasKey(keyStr))
+			           return;
+
+		           switch (shape->getType(keyStr)) {
 			           case prtx::Attributable::PT_STRING: {
-				           const auto v = shape->getString(key);
+				           const auto v = shape->getString(keyStr);
 				           hc->attrString(initialShapeIndex, shape->getID(), key, v.c_str());
 				           break;
 			           }
 			           case prtx::Attributable::PT_FLOAT: {
-				           const auto v = shape->getFloat(key);
+				           const auto v = shape->getFloat(keyStr);
 				           hc->attrFloat(initialShapeIndex, shape->getID(), key, v);
 				           break;
 			           }
 			           case prtx::Attributable::PT_BOOL: {
-				           const auto v = shape->getBool(key);
+				           const auto v = shape->getBool(keyStr);
 				           hc->attrBool(initialShapeIndex, shape->getID(), key, (v == prtx::PRTX_TRUE));
 				           break;
 			           }

--- a/src/codec/encoder/HoudiniEncoder.cpp
+++ b/src/codec/encoder/HoudiniEncoder.cpp
@@ -302,6 +302,24 @@ void forwardGenericAttributes(HoudiniCallbacks* hc, size_t initialShapeIndex, co
 				           hc->attrBool(initialShapeIndex, shape->getID(), key, (v == prtx::PRTX_TRUE));
 				           break;
 			           }
+			           case prtx::Attributable::PT_STRING_ARRAY: {
+				           const prtx::WStringVector& v = shape->getStringArray(keyStr);
+				           const std::vector<const wchar_t*> vPtrs = toPtrVec(v);
+				           hc->attrStringArray(initialShapeIndex, shape->getID(), key, vPtrs.data(), vPtrs.size(), 1);
+				           break;
+			           }
+			           case prtx::Attributable::PT_FLOAT_ARRAY: {
+				           const prtx::DoubleVector& v = shape->getFloatArray(keyStr);
+				           hc->attrFloatArray(initialShapeIndex, shape->getID(), key, v.data(), v.size(), 1);
+				           break;
+			           }
+			           case prtx::Attributable::PT_BOOL_ARRAY: {
+				           const prtx::BoolVector& v = shape->getBoolArray(keyStr);
+				           const std::unique_ptr<bool[]> vPtrs(new bool[v.size()]);
+				           for (size_t i = 0; i < v.size(); i++) vPtrs[i] = prtx::toPrimitive(v[i]);
+				           hc->attrBoolArray(initialShapeIndex, shape->getID(), key, vPtrs.get(), v.size(), 1);
+				           break;
+			           }
 			           default:
 				           break;
 		           }

--- a/src/codec/encoder/HoudiniEncoder.cpp
+++ b/src/codec/encoder/HoudiniEncoder.cpp
@@ -17,48 +17,48 @@
 #include "HoudiniEncoder.h"
 #include "HoudiniCallbacks.h"
 
+#include "prtx/Attributable.h"
 #include "prtx/Exception.h"
-#include "prtx/Log.h"
-#include "prtx/Geometry.h"
-#include "prtx/Mesh.h"
-#include "prtx/Material.h"
-#include "prtx/Shape.h"
-#include "prtx/ShapeIterator.h"
 #include "prtx/ExtensionManager.h"
 #include "prtx/GenerateContext.h"
-#include "prtx/Attributable.h"
-#include "prtx/URI.h"
+#include "prtx/Geometry.h"
+#include "prtx/Log.h"
+#include "prtx/Material.h"
+#include "prtx/Mesh.h"
 #include "prtx/ReportsCollector.h"
+#include "prtx/Shape.h"
+#include "prtx/ShapeIterator.h"
+#include "prtx/URI.h"
 
 #include "prt/prt.h"
 
+#include <algorithm>
 #include <iostream>
+#include <limits>
+#include <memory>
+#include <numeric>
+#include <set>
 #include <sstream>
 #include <vector>
-#include <numeric>
-#include <limits>
-#include <algorithm>
-#include <set>
-#include <memory>
-
 
 namespace {
 
-constexpr bool           DBG                = false;
+constexpr bool DBG = false;
 
-constexpr const wchar_t* ENC_NAME           = L"SideFX(tm) Houdini(tm) Encoder";
-constexpr const wchar_t* ENC_DESCRIPTION    = L"Encodes geometry into the Houdini format.";
+constexpr const wchar_t* ENC_NAME = L"SideFX(tm) Houdini(tm) Encoder";
+constexpr const wchar_t* ENC_DESCRIPTION = L"Encodes geometry into the Houdini format.";
 
-const prtx::EncodePreparator::PreparationFlags PREP_FLAGS = prtx::EncodePreparator::PreparationFlags()
-	.instancing(false)
-	.mergeByMaterial(false)
-	.triangulate(false)
-	.processHoles(prtx::HoleProcessor::TRIANGULATE_FACES_WITH_HOLES)
-	.mergeVertices(true)
-	.cleanupVertexNormals(true)
-	.cleanupUVs(true)
-	.processVertexNormals(prtx::VertexNormalProcessor::SET_MISSING_TO_FACE_NORMALS)
-	.indexSharing(prtx::EncodePreparator::PreparationFlags::INDICES_SAME_FOR_ALL_VERTEX_ATTRIBUTES);
+const prtx::EncodePreparator::PreparationFlags PREP_FLAGS =
+        prtx::EncodePreparator::PreparationFlags()
+                .instancing(false)
+                .mergeByMaterial(false)
+                .triangulate(false)
+                .processHoles(prtx::HoleProcessor::TRIANGULATE_FACES_WITH_HOLES)
+                .mergeVertices(true)
+                .cleanupVertexNormals(true)
+                .cleanupUVs(true)
+                .processVertexNormals(prtx::VertexNormalProcessor::SET_MISSING_TO_FACE_NORMALS)
+                .indexSharing(prtx::EncodePreparator::PreparationFlags::INDICES_SAME_FOR_ALL_VERTEX_ATTRIBUTES);
 
 std::vector<const wchar_t*> toPtrVec(const prtx::WStringVector& wsv) {
 	std::vector<const wchar_t*> pw(wsv.size());
@@ -67,7 +67,7 @@ std::vector<const wchar_t*> toPtrVec(const prtx::WStringVector& wsv) {
 	return pw;
 }
 
-template<typename T>
+template <typename T>
 std::pair<std::vector<const T*>, std::vector<size_t>> toPtrVec(const std::vector<std::vector<T>>& v) {
 	std::vector<const T*> pv(v.size());
 	std::vector<size_t> ps(v.size());
@@ -78,107 +78,106 @@ std::pair<std::vector<const T*>, std::vector<size_t>> toPtrVec(const std::vector
 	return std::make_pair(pv, ps);
 }
 
-std::wstring uriToPath(const prtx::TexturePtr& t){
+std::wstring uriToPath(const prtx::TexturePtr& t) {
 	return t->getURI()->getPath();
 }
 
 // we blacklist all CGA-style material attribute keys, see prtx/Material.h
 const std::set<std::wstring> MATERIAL_ATTRIBUTE_BLACKLIST = {
-	L"ambient.b",
-	L"ambient.g",
-	L"ambient.r",
-	L"bumpmap.rw",
-	L"bumpmap.su",
-	L"bumpmap.sv",
-	L"bumpmap.tu",
-	L"bumpmap.tv",
-	L"color.a",
-	L"color.b",
-	L"color.g",
-	L"color.r",
-	L"color.rgb",
-	L"colormap.rw",
-	L"colormap.su",
-	L"colormap.sv",
-	L"colormap.tu",
-	L"colormap.tv",
-	L"dirtmap.rw",
-	L"dirtmap.su",
-	L"dirtmap.sv",
-	L"dirtmap.tu",
-	L"dirtmap.tv",
-	L"normalmap.rw",
-	L"normalmap.su",
-	L"normalmap.sv",
-	L"normalmap.tu",
-	L"normalmap.tv",
-	L"opacitymap.rw",
-	L"opacitymap.su",
-	L"opacitymap.sv",
-	L"opacitymap.tu",
-	L"opacitymap.tv",
-	L"specular.b",
-	L"specular.g",
-	L"specular.r",
-	L"specularmap.rw",
-	L"specularmap.su",
-	L"specularmap.sv",
-	L"specularmap.tu",
-	L"specularmap.tv",
-	L"bumpmap",
-	L"colormap",
-	L"dirtmap",
-	L"normalmap",
-	L"opacitymap",
-	L"specularmap"
+        L"ambient.b",
+        L"ambient.g",
+        L"ambient.r",
+        L"bumpmap.rw",
+        L"bumpmap.su",
+        L"bumpmap.sv",
+        L"bumpmap.tu",
+        L"bumpmap.tv",
+        L"color.a",
+        L"color.b",
+        L"color.g",
+        L"color.r",
+        L"color.rgb",
+        L"colormap.rw",
+        L"colormap.su",
+        L"colormap.sv",
+        L"colormap.tu",
+        L"colormap.tv",
+        L"dirtmap.rw",
+        L"dirtmap.su",
+        L"dirtmap.sv",
+        L"dirtmap.tu",
+        L"dirtmap.tv",
+        L"normalmap.rw",
+        L"normalmap.su",
+        L"normalmap.sv",
+        L"normalmap.tu",
+        L"normalmap.tv",
+        L"opacitymap.rw",
+        L"opacitymap.su",
+        L"opacitymap.sv",
+        L"opacitymap.tu",
+        L"opacitymap.tv",
+        L"specular.b",
+        L"specular.g",
+        L"specular.r",
+        L"specularmap.rw",
+        L"specularmap.su",
+        L"specularmap.sv",
+        L"specularmap.tu",
+        L"specularmap.tv",
+        L"bumpmap",
+        L"colormap",
+        L"dirtmap",
+        L"normalmap",
+        L"opacitymap",
+        L"specularmap"
 
 #if PRT_VERSION_MAJOR > 1
-	// also blacklist CGA-style PBR attrs from CE 2019.0, PRT 2.x
-	,
-	L"opacitymap.mode",
-	L"emissive.b",
-	L"emissive.g",
-	L"emissive.r",
-	L"emissivemap.rw",
-	L"emissivemap.su",
-	L"emissivemap.sv",
-	L"emissivemap.tu",
-	L"emissivemap.tv",
-	L"metallicmap.rw",
-	L"metallicmap.su",
-	L"metallicmap.sv",
-	L"metallicmap.tu",
-	L"metallicmap.tv",
-	L"occlusionmap.rw",
-	L"occlusionmap.su",
-	L"occlusionmap.sv",
-	L"occlusionmap.tu",
-	L"occlusionmap.tv",
-	L"roughnessmap.rw",
-	L"roughnessmap.su",
-	L"roughnessmap.sv",
-	L"roughnessmap.tu",
-	L"roughnessmap.tv",
-	L"emissivemap",
-	L"metallicmap",
-	L"occlusionmap",
-	L"roughnessmap"
+        // also blacklist CGA-style PBR attrs from CE 2019.0, PRT 2.x
+        ,
+        L"opacitymap.mode",
+        L"emissive.b",
+        L"emissive.g",
+        L"emissive.r",
+        L"emissivemap.rw",
+        L"emissivemap.su",
+        L"emissivemap.sv",
+        L"emissivemap.tu",
+        L"emissivemap.tv",
+        L"metallicmap.rw",
+        L"metallicmap.su",
+        L"metallicmap.sv",
+        L"metallicmap.tu",
+        L"metallicmap.tv",
+        L"occlusionmap.rw",
+        L"occlusionmap.su",
+        L"occlusionmap.sv",
+        L"occlusionmap.tu",
+        L"occlusionmap.tv",
+        L"roughnessmap.rw",
+        L"roughnessmap.su",
+        L"roughnessmap.sv",
+        L"roughnessmap.tu",
+        L"roughnessmap.tv",
+        L"emissivemap",
+        L"metallicmap",
+        L"occlusionmap",
+        L"roughnessmap"
 #endif
 };
 
-void convertMaterialToAttributeMap(
-		prtx::PRTUtils::AttributeMapBuilderPtr& aBuilder,
-		const prtx::Material& prtxAttr,
-		const prtx::WStringVector& keys
-) {
-	if (DBG) log_debug(L"-- converting material: %1%") % prtxAttr.name();
-	for(const auto& key : keys) {
+void convertMaterialToAttributeMap(prtx::PRTUtils::AttributeMapBuilderPtr& aBuilder, const prtx::Material& prtxAttr,
+                                   const prtx::WStringVector& keys) {
+	if (DBG)
+		log_debug(L"-- converting material: %1%") % prtxAttr.name();
+	for (const auto& key : keys) {
 		if (MATERIAL_ATTRIBUTE_BLACKLIST.count(key) > 0)
 			continue;
 
-		if (DBG) log_debug(L"   key: %1%") % key;
+		if (DBG)
+			log_debug(L"   key: %1%") % key;
 
-		switch(prtxAttr.getType(key)) {
+		switch (prtxAttr.getType(key)) {
 			case prt::Attributable::PT_BOOL:
 				aBuilder->setBool(key.c_str(), prtxAttr.getBool(key) == prtx::PRTX_TRUE);
 				break;
@@ -193,7 +192,7 @@ void convertMaterialToAttributeMap(
 
 			case prt::Attributable::PT_STRING: {
 				const std::wstring& v = prtxAttr.getString(key); // explicit copy
-				aBuilder->setString(key.c_str(), v.c_str()); // also passing on empty strings
+				aBuilder->setString(key.c_str(), v.c_str());     // also passing on empty strings
 				break;
 			}
 
@@ -244,7 +243,8 @@ void convertMaterialToAttributeMap(
 			}
 
 			default:
-				if (DBG) log_debug(L"ignored atttribute '%s' with type %d") % key % prtxAttr.getType(key);
+				if (DBG)
+					log_debug(L"ignored atttribute '%s' with type %d") % key % prtxAttr.getType(key);
 				break;
 		}
 	}
@@ -254,15 +254,15 @@ void convertReportsToAttributeMap(prtx::PRTUtils::AttributeMapBuilderPtr& amb, c
 	if (!r)
 		return;
 
-	for (const auto& b: r->mBools)
+	for (const auto& b : r->mBools)
 		amb->setBool(b.first->c_str(), b.second);
-	for (const auto& f: r->mFloats)
+	for (const auto& f : r->mFloats)
 		amb->setFloat(f.first->c_str(), f.second);
-	for (const auto& s: r->mStrings)
+	for (const auto& s : r->mStrings)
 		amb->setString(s.first->c_str(), s.second->c_str());
 }
 
-template<typename F>
+template <typename F>
 void forEachKey(prt::Attributable const* a, F f) {
 	if (a == nullptr)
 		return;
@@ -276,28 +276,30 @@ void forEachKey(prt::Attributable const* a, F f) {
 	}
 }
 
-void forwardGenericAttributes(HoudiniCallbacks* hc, size_t initialShapeIndex, const prtx::InitialShape& initialShape, const prtx::ShapePtr& shape) {
-	forEachKey(initialShape.getAttributeMap(), [&hc,&shape,&initialShapeIndex,&initialShape](prt::Attributable const* a, wchar_t const* key) {
-		switch (shape->getType(key)) {
-			case prtx::Attributable::PT_STRING: {
-				const auto v = shape->getString(key);
-				hc->attrString(initialShapeIndex, shape->getID(), key, v.c_str());
-				break;
-			}
-			case prtx::Attributable::PT_FLOAT: {
-				const auto v = shape->getFloat(key);
-				hc->attrFloat(initialShapeIndex, shape->getID(), key, v);
-				break;
-			}
-			case prtx::Attributable::PT_BOOL: {
-				const auto v = shape->getBool(key);
-				hc->attrBool(initialShapeIndex, shape->getID(), key, (v == prtx::PRTX_TRUE));
-				break;
-			}
-			default:
-				break;
-		}
-	});
+void forwardGenericAttributes(HoudiniCallbacks* hc, size_t initialShapeIndex, const prtx::InitialShape& initialShape,
+                              const prtx::ShapePtr& shape) {
+	forEachKey(initialShape.getAttributeMap(),
+	           [&hc, &shape, &initialShapeIndex, &initialShape](prt::Attributable const* a, wchar_t const* key) {
+		           switch (shape->getType(key)) {
+			           case prtx::Attributable::PT_STRING: {
+				           const auto v = shape->getString(key);
+				           hc->attrString(initialShapeIndex, shape->getID(), key, v.c_str());
+				           break;
+			           }
+			           case prtx::Attributable::PT_FLOAT: {
+				           const auto v = shape->getFloat(key);
+				           hc->attrFloat(initialShapeIndex, shape->getID(), key, v);
+				           break;
+			           }
+			           case prtx::Attributable::PT_BOOL: {
+				           const auto v = shape->getBool(key);
+				           hc->attrBool(initialShapeIndex, shape->getID(), key, (v == prtx::PRTX_TRUE));
+				           break;
+			           }
+			           default:
+				           break;
+		           }
+	           });
 }
 
 using AttributeMapNOPtrVector = std::vector<const prt::AttributeMap*>;
@@ -305,43 +307,46 @@ using AttributeMapNOPtrVector = std::vector<const prt::AttributeMap*>;
 struct AttributeMapNOPtrVectorOwner {
 	AttributeMapNOPtrVector v;
 	~AttributeMapNOPtrVectorOwner() {
-		for (const auto& m: v) {
-			if (m) m->destroy();
+		for (const auto& m : v) {
+			if (m)
+				m->destroy();
 		}
 	}
 };
 
 struct TextureUVMapping {
 	std::wstring key;
-	uint8_t      index;
-	int8_t       uvSet;
+	uint8_t index;
+	int8_t uvSet;
 };
 
 const std::vector<TextureUVMapping> TEXTURE_UV_MAPPINGS = []() -> std::vector<TextureUVMapping> {
 	return {
 		// shader key   | idx | uv set  | CGA key
-		{ L"diffuseMap",   0,    0 },  // colormap
-		{ L"bumpMap",      0,    1 },  // bumpmap
-		{ L"diffuseMap",   1,    2 },  // dirtmap
-		{ L"specularMap",  0,    3 },  // specularmap
-		{ L"opacityMap",   0,    4 },  // opacitymap
-		{ L"normalMap",    0,    5 }   // normalmap
+		{L"diffuseMap", 0, 0},          // colormap
+		        {L"bumpMap", 0, 1},     // bumpmap
+		        {L"diffuseMap", 1, 2},  // dirtmap
+		        {L"specularMap", 0, 3}, // specularmap
+		        {L"opacityMap", 0, 4},  // opacitymap
+		{
+			L"normalMap", 0, 5
+		} // normalmap
 
 #if PRT_VERSION_MAJOR > 1
-		,
-		{ L"emissiveMap",  0,    6 },  // emissivemap
-		{ L"occlusionMap", 0,    7 },  // occlusionmap
-		{ L"roughnessMap", 0,    8 },  // roughnessmap
-		{ L"metallicMap",  0,    9 }   // metallicmap
+		, {L"emissiveMap", 0, 6},        // emissivemap
+		        {L"occlusionMap", 0, 7}, // occlusionmap
+		        {L"roughnessMap", 0, 8}, // roughnessmap
+		{
+			L"metallicMap", 0, 9
+		} // metallicmap
 #endif
-
 	};
 }();
 
 // return the highest required uv set (where a valid texture is present)
 uint32_t scanValidTextures(const prtx::MaterialPtr& mat) {
 	int8_t highestUVSet = -1;
-	for (const auto& t: TEXTURE_UV_MAPPINGS) {
+	for (const auto& t : TEXTURE_UV_MAPPINGS) {
 		const auto& ta = mat->getTextureArray(t.key);
 		if (ta.size() > t.index && ta[t.index]->isValid())
 			highestUVSet = std::max(highestUVSet, t.uvSet);
@@ -349,7 +354,7 @@ uint32_t scanValidTextures(const prtx::MaterialPtr& mat) {
 	if (highestUVSet < 0)
 		return 0;
 	else
-		return highestUVSet+1;
+		return highestUVSet + 1;
 }
 
 const prtx::DoubleVector EMPTY_UVS;
@@ -357,10 +362,10 @@ const prtx::IndexVector EMPTY_IDX;
 
 } // namespace
 
-
 namespace detail {
 
-SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, const std::vector<prtx::MaterialPtrVector>& materials) {
+SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries,
+                                     const std::vector<prtx::MaterialPtrVector>& materials) {
 	// PASS 1: scan
 	uint32_t numCoords = 0;
 	uint32_t numNormalCoords = 0;
@@ -368,11 +373,11 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, 
 	uint32_t numIndices = 0;
 	uint32_t maxNumUVSets = 0;
 	auto matsIt = materials.cbegin();
-	for (const auto& geo: geometries) {
+	for (const auto& geo : geometries) {
 		const prtx::MeshPtrVector& meshes = geo->getMeshes();
 		const prtx::MaterialPtrVector& mats = *matsIt;
 		auto matIt = mats.cbegin();
-		for (const auto& mesh: meshes) {
+		for (const auto& mesh : meshes) {
 			numCoords += mesh->getVertexCoords().size();
 			numNormalCoords += mesh->getVertexNormalsCoords().size();
 
@@ -392,9 +397,9 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, 
 	// PASS 2: copy
 	uint32_t vertexIndexBase = 0;
 	std::vector<uint32_t> uvIndexBases(maxNumUVSets, 0u);
-	for (const auto& geo: geometries) {
+	for (const auto& geo : geometries) {
 		const prtx::MeshPtrVector& meshes = geo->getMeshes();
-		for (const auto& mesh: meshes) {
+		for (const auto& mesh : meshes) {
 			// append points
 			const prtx::DoubleVector& verts = mesh->getVertexCoords();
 			sg.coords.insert(sg.coords.end(), verts.begin(), verts.end());
@@ -408,8 +413,10 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, 
 			// - if mesh has less uv sets than maxNumUVSets, copy uv set 0 to the missing higher sets
 			const uint32_t numUVSets = mesh->getUVSetsCount();
 			const prtx::DoubleVector& uvs0 = (numUVSets > 0) ? mesh->getUVCoords(0) : EMPTY_UVS;
-			const prtx::IndexVector faceUVCounts0 = (numUVSets > 0) ? mesh->getFaceUVCounts(0) : prtx::IndexVector(mesh->getFaceCount(), 0);
-			if (DBG) log_debug("-- mesh: numUVSets = %1%") % numUVSets;
+			const prtx::IndexVector faceUVCounts0 =
+			        (numUVSets > 0) ? mesh->getFaceUVCounts(0) : prtx::IndexVector(mesh->getFaceCount(), 0);
+			if (DBG)
+				log_debug("-- mesh: numUVSets = %1%") % numUVSets;
 
 			for (uint32_t uvSet = 0; uvSet < sg.uvs.size(); uvSet++) {
 				// append texture coordinates
@@ -419,20 +426,26 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, 
 				tgt.insert(tgt.end(), src.begin(), src.end());
 
 				// append uv face counts
-				const prtx::IndexVector& faceUVCounts = (uvSet < numUVSets && !uvs.empty()) ? mesh->getFaceUVCounts(uvSet) : faceUVCounts0;
+				const prtx::IndexVector& faceUVCounts =
+				        (uvSet < numUVSets && !uvs.empty()) ? mesh->getFaceUVCounts(uvSet) : faceUVCounts0;
 				assert(faceUVCounts.size() == mesh->getFaceCount());
 				auto& tgtCnts = sg.uvCounts[uvSet];
 				tgtCnts.insert(tgtCnts.end(), faceUVCounts.begin(), faceUVCounts.end());
-				if (DBG) log_debug("   -- uvset %1%: face counts size = %2%") % uvSet % faceUVCounts.size();
+				if (DBG)
+					log_debug("   -- uvset %1%: face counts size = %2%") % uvSet % faceUVCounts.size();
 
 				// append uv vertex indices
 				for (uint32_t fi = 0, faceCount = faceUVCounts.size(); fi < faceCount; ++fi) {
 					const uint32_t* faceUVIdx0 = (numUVSets > 0) ? mesh->getFaceUVIndices(fi, 0) : EMPTY_IDX.data();
-					const uint32_t* faceUVIdx = (uvSet < numUVSets && !uvs.empty()) ? mesh->getFaceUVIndices(fi, uvSet) : faceUVIdx0;
+					const uint32_t* faceUVIdx =
+					        (uvSet < numUVSets && !uvs.empty()) ? mesh->getFaceUVIndices(fi, uvSet) : faceUVIdx0;
 					const uint32_t faceUVCnt = faceUVCounts[fi];
-					if (DBG) log_debug("      fi %1%: faceUVCnt = %2%, faceVtxCnt = %3%") % fi % faceUVCnt % mesh->getFaceVertexCount(fi);
+					if (DBG)
+						log_debug("      fi %1%: faceUVCnt = %2%, faceVtxCnt = %3%") % fi % faceUVCnt %
+						        mesh->getFaceVertexCount(fi);
 					for (uint32_t vi = 0; vi < faceUVCnt; vi++)
-						sg.uvIndices[uvSet].push_back(uvIndexBases[uvSet] + faceUVIdx[faceUVCnt - vi - 1]); // reverse winding
+						sg.uvIndices[uvSet].push_back(uvIndexBases[uvSet] +
+						                              faceUVIdx[faceUVCnt - vi - 1]); // reverse winding
 				}
 
 				uvIndexBases[uvSet] += src.size() / 2u;
@@ -449,24 +462,25 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries, 
 
 			vertexIndexBase += (uint32_t)verts.size() / 3u;
 		} // for all meshes
-	} // for all geometries
+	}     // for all geometries
 
 	return sg;
 }
 
 } // namespace detail
 
-
 HoudiniEncoder::HoudiniEncoder(const std::wstring& id, const prt::AttributeMap* options, prt::Callbacks* callbacks)
-: prtx::GeometryEncoder(id, options, callbacks)
-{  }
+    : prtx::GeometryEncoder(id, options, callbacks) {}
 
 void HoudiniEncoder::init(prtx::GenerateContext&) {
 	prt::Callbacks* cb = getCallbacks();
-	if (DBG) log_debug("HoudiniEncoder::init: cb = %x") % (size_t)cb;
+	if (DBG)
+		log_debug("HoudiniEncoder::init: cb = %x") % (size_t)cb;
 	auto* oh = dynamic_cast<HoudiniCallbacks*>(cb);
-	if (DBG) log_debug("                   oh = %x") % (size_t)oh;
-	if(oh == nullptr) throw prtx::StatusException(prt::STATUS_ILLEGAL_CALLBACK_OBJECT);
+	if (DBG)
+		log_debug("                   oh = %x") % (size_t)oh;
+	if (oh == nullptr)
+		throw prtx::StatusException(prt::STATUS_ILLEGAL_CALLBACK_OBJECT);
 }
 
 void HoudiniEncoder::encode(prtx::GenerateContext& context, size_t initialShapeIndex) {
@@ -475,14 +489,15 @@ void HoudiniEncoder::encode(prtx::GenerateContext& context, size_t initialShapeI
 
 	const bool emitAttrs = getOptions()->getBool(EO_EMIT_ATTRIBUTES);
 
-	prtx::DefaultNamePreparator        namePrep;
-	prtx::NamePreparator::NamespacePtr nsMesh     = namePrep.newNamespace();
+	prtx::DefaultNamePreparator namePrep;
+	prtx::NamePreparator::NamespacePtr nsMesh = namePrep.newNamespace();
 	prtx::NamePreparator::NamespacePtr nsMaterial = namePrep.newNamespace();
 	prtx::EncodePreparatorPtr encPrep = prtx::EncodePreparator::create(true, namePrep, nsMesh, nsMaterial);
 
 	// generate geometry
 	prtx::ReportsAccumulatorPtr reportsAccumulator{prtx::WriteFirstReportsAccumulator::create()};
-	prtx::ReportingStrategyPtr reportsCollector{prtx::LeafShapeReportingStrategy::create(context, initialShapeIndex, reportsAccumulator)};
+	prtx::ReportingStrategyPtr reportsCollector{
+	        prtx::LeafShapeReportingStrategy::create(context, initialShapeIndex, reportsAccumulator)};
 	prtx::LeafIteratorPtr li = prtx::LeafIterator::create(context, initialShapeIndex);
 	for (prtx::ShapePtr shape = li->getNext(); shape; shape = li->getNext()) {
 		prtx::ReportsPtr r = reportsCollector->getReports(shape->getID());
@@ -499,9 +514,7 @@ void HoudiniEncoder::encode(prtx::GenerateContext& context, size_t initialShapeI
 }
 
 void HoudiniEncoder::convertGeometry(const prtx::InitialShape& initialShape,
-                                     const prtx::EncodePreparator::InstanceVector& instances,
-                                     HoudiniCallbacks* cb)
-{
+                                     const prtx::EncodePreparator::InstanceVector& instances, HoudiniCallbacks* cb) {
 	const bool emitMaterials = getOptions()->getBool(EO_EMIT_MATERIALS);
 	const bool emitReports = getOptions()->getBool(EO_EMIT_REPORTS);
 
@@ -515,7 +528,7 @@ void HoudiniEncoder::convertGeometry(const prtx::InitialShape& initialShape,
 	reports.reserve(instances.size());
 	shapeIDs.reserve(instances.size());
 
-	for (const auto& inst: instances) {
+	for (const auto& inst : instances) {
 		geometries.push_back(inst.getGeometry());
 		materials.push_back(inst.getMaterials());
 		reports.push_back(inst.getReports());
@@ -539,7 +552,7 @@ void HoudiniEncoder::convertGeometry(const prtx::InitialShape& initialShape,
 	auto matIt = materials.cbegin();
 	auto repIt = reports.cbegin();
 	prtx::PRTUtils::AttributeMapBuilderPtr amb(prt::AttributeMapBuilder::create());
-	for (const auto& geo: geometries) {
+	for (const auto& geo : geometries) {
 		const prtx::MeshPtrVector& meshes = geo->getMeshes();
 
 		for (size_t mi = 0; mi < meshes.size(); mi++) {
@@ -556,7 +569,8 @@ void HoudiniEncoder::convertGeometry(const prtx::InitialShape& initialShape,
 			if (emitReports) {
 				convertReportsToAttributeMap(amb, *repIt);
 				reportAttrMaps.v.push_back(amb->createAttributeMapAndReset());
-				if (DBG) log_debug("report attr map: %1%") % prtx::PRTUtils::objectToXML(reportAttrMaps.v.back());
+				if (DBG)
+					log_debug("report attr map: %1%") % prtx::PRTUtils::objectToXML(reportAttrMaps.v.back());
 			}
 
 			faceCount += m->getFaceCount();
@@ -567,9 +581,9 @@ void HoudiniEncoder::convertGeometry(const prtx::InitialShape& initialShape,
 	}
 	faceRanges.push_back(faceCount); // close last range
 
-	assert(matAttrMaps.v.empty() || matAttrMaps.v.size() == faceRanges.size()-1);
-	assert(reportAttrMaps.v.empty() || reportAttrMaps.v.size() == faceRanges.size()-1);
-	assert(shapeIDs.size() == faceRanges.size()-1);
+	assert(matAttrMaps.v.empty() || matAttrMaps.v.size() == faceRanges.size() - 1);
+	assert(reportAttrMaps.v.empty() || reportAttrMaps.v.size() == faceRanges.size() - 1);
+	assert(shapeIDs.size() == faceRanges.size() - 1);
 
 	assert(sg.uvs.size() == sg.uvCounts.size());
 	assert(sg.uvs.size() == sg.uvIndices.size());
@@ -581,28 +595,20 @@ void HoudiniEncoder::convertGeometry(const prtx::InitialShape& initialShape,
 	assert(sg.uvs.size() == puvCounts.first.size());
 	assert(sg.uvs.size() == puvCounts.second.size());
 
-	cb->add(initialShape.getName(),
-	        sg.coords.data(), sg.coords.size(),
-			sg.normals.data(), sg.normals.size(),
-			sg.counts.data(), sg.counts.size(),
-			sg.indices.data(), sg.indices.size(),
+	cb->add(initialShape.getName(), sg.coords.data(), sg.coords.size(), sg.normals.data(), sg.normals.size(),
+	        sg.counts.data(), sg.counts.size(), sg.indices.data(), sg.indices.size(),
 
-			puvs.first.data(), puvs.second.data(),
-			puvCounts.first.data(), puvCounts.second.data(),
-			puvIndices.first.data(), puvIndices.second.data(),
-			sg.uvs.size(),
+	        puvs.first.data(), puvs.second.data(), puvCounts.first.data(), puvCounts.second.data(),
+	        puvIndices.first.data(), puvIndices.second.data(), sg.uvs.size(),
 
-			faceRanges.data(), faceRanges.size(),
-	        matAttrMaps.v.empty() ? nullptr : matAttrMaps.v.data(),
-	        reportAttrMaps.v.empty() ? nullptr : reportAttrMaps.v.data(),
-			shapeIDs.data());
+	        faceRanges.data(), faceRanges.size(), matAttrMaps.v.empty() ? nullptr : matAttrMaps.v.data(),
+	        reportAttrMaps.v.empty() ? nullptr : reportAttrMaps.v.data(), shapeIDs.data());
 
-	if (DBG) log_debug("HoudiniEncoder::convertGeometry: end");
+	if (DBG)
+		log_debug("HoudiniEncoder::convertGeometry: end");
 }
 
-void HoudiniEncoder::finish(prtx::GenerateContext& /*context*/) {
-}
-
+void HoudiniEncoder::finish(prtx::GenerateContext& /*context*/) {}
 
 HoudiniEncoderFactory* HoudiniEncoderFactory::createInstance() {
 	prtx::EncoderInfoBuilder encoderInfoBuilder;
@@ -614,8 +620,8 @@ HoudiniEncoderFactory* HoudiniEncoderFactory::createInstance() {
 
 	prtx::PRTUtils::AttributeMapBuilderPtr amb(prt::AttributeMapBuilder::create());
 	amb->setBool(EO_EMIT_ATTRIBUTES, prtx::PRTX_FALSE);
-	amb->setBool(EO_EMIT_MATERIALS,  prtx::PRTX_FALSE);
-	amb->setBool(EO_EMIT_REPORTS,    prtx::PRTX_FALSE);
+	amb->setBool(EO_EMIT_MATERIALS, prtx::PRTX_FALSE);
+	amb->setBool(EO_EMIT_REPORTS, prtx::PRTX_FALSE);
 	encoderInfoBuilder.setDefaultOptions(amb->createAttributeMap());
 
 	return new HoudiniEncoderFactory(encoderInfoBuilder.create());

--- a/src/codec/encoder/HoudiniEncoder.cpp
+++ b/src/codec/encoder/HoudiniEncoder.cpp
@@ -402,8 +402,8 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries,
 		const prtx::MaterialPtrVector& mats = *matsIt;
 		auto matIt = mats.cbegin();
 		for (const auto& mesh : meshes) {
-			numCoords += mesh->getVertexCoords().size();
-			numNormalCoords += mesh->getVertexNormalsCoords().size();
+			numCoords += static_cast<uint32_t>(mesh->getVertexCoords().size());
+			numNormalCoords += static_cast<uint32_t>(mesh->getVertexNormalsCoords().size());
 
 			numCounts += mesh->getFaceCount();
 			const auto& vtxCnts = mesh->getFaceVertexCounts();
@@ -459,7 +459,7 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries,
 					log_debug("   -- uvset %1%: face counts size = %2%") % uvSet % faceUVCounts.size();
 
 				// append uv vertex indices
-				for (uint32_t fi = 0, faceCount = faceUVCounts.size(); fi < faceCount; ++fi) {
+				for (uint32_t fi = 0, faceCount = static_cast<uint32_t>(faceUVCounts.size()); fi < faceCount; ++fi) {
 					const uint32_t* faceUVIdx0 = (numUVSets > 0) ? mesh->getFaceUVIndices(fi, 0) : EMPTY_IDX.data();
 					const uint32_t* faceUVIdx =
 					        (uvSet < numUVSets && !uvs.empty()) ? mesh->getFaceUVIndices(fi, uvSet) : faceUVIdx0;
@@ -472,7 +472,7 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries,
 						                              faceUVIdx[faceUVCnt - vi - 1]); // reverse winding
 				}
 
-				uvIndexBases[uvSet] += src.size() / 2u;
+				uvIndexBases[uvSet] += static_cast<uint32_t>(src.size()) / 2u;
 			} // for all uv sets
 
 			// append counts and indices for vertices and vertex normals
@@ -623,7 +623,7 @@ void HoudiniEncoder::convertGeometry(const prtx::InitialShape& initialShape,
 	        sg.counts.data(), sg.counts.size(), sg.indices.data(), sg.indices.size(),
 
 	        puvs.first.data(), puvs.second.data(), puvCounts.first.data(), puvCounts.second.data(),
-	        puvIndices.first.data(), puvIndices.second.data(), sg.uvs.size(),
+	        puvIndices.first.data(), puvIndices.second.data(), static_cast<uint32_t>(sg.uvs.size()),
 
 	        faceRanges.data(), faceRanges.size(), matAttrMaps.v.empty() ? nullptr : matAttrMaps.v.data(),
 	        reportAttrMaps.v.empty() ? nullptr : reportAttrMaps.v.data(), shapeIDs.data());

--- a/src/codec/encoder/HoudiniEncoder.h
+++ b/src/codec/encoder/HoudiniEncoder.h
@@ -18,40 +18,39 @@
 
 #include "../CodecMain.h"
 
-#include "prtx/Mesh.h"
-#include "prtx/ResolveMap.h"
+#include "prtx/EncodePreparator.h"
 #include "prtx/Encoder.h"
 #include "prtx/EncoderFactory.h"
 #include "prtx/EncoderInfoBuilder.h"
+#include "prtx/Mesh.h"
 #include "prtx/PRTUtils.h"
+#include "prtx/ResolveMap.h"
 #include "prtx/Singleton.h"
-#include "prtx/EncodePreparator.h"
 
 #include "prt/ContentType.h"
 #include "prt/InitialShape.h"
 
-#include <string>
 #include <iostream>
 #include <stdexcept>
-
+#include <string>
 
 class HoudiniCallbacks;
 
 namespace detail {
 
 struct SerializedGeometry {
-	prtx::DoubleVector              coords;
-	prtx::DoubleVector              normals; // uses same indexing as coords
-	std::vector<uint32_t>           counts;
-	std::vector<uint32_t>           indices;
+	prtx::DoubleVector coords;
+	prtx::DoubleVector normals; // uses same indexing as coords
+	std::vector<uint32_t> counts;
+	std::vector<uint32_t> indices;
 
 	std::vector<prtx::DoubleVector> uvs;
-	std::vector<prtx::IndexVector>  uvCounts;
-	std::vector<prtx::IndexVector>  uvIndices;
+	std::vector<prtx::IndexVector> uvCounts;
+	std::vector<prtx::IndexVector> uvIndices;
 
-	SerializedGeometry(uint32_t numCoords, uint32_t numNormalCoords, uint32_t numCounts, uint32_t numIndices, uint32_t uvSets)
-		: uvs(uvSets), uvCounts(uvSets), uvIndices(uvSets)
-	{
+	SerializedGeometry(uint32_t numCoords, uint32_t numNormalCoords, uint32_t numCounts, uint32_t numIndices,
+	                   uint32_t uvSets)
+	    : uvs(uvSets), uvCounts(uvSets), uvIndices(uvSets) {
 		coords.reserve(3 * numCoords);
 		normals.reserve(3 * numNormalCoords);
 		counts.reserve(numCounts);
@@ -60,10 +59,10 @@ struct SerializedGeometry {
 };
 
 // visible for tests
-CODEC_EXPORTS_API SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector &geometries, const std::vector<prtx::MaterialPtrVector>& materials);
+CODEC_EXPORTS_API SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries,
+                                                       const std::vector<prtx::MaterialPtrVector>& materials);
 
 } // namespace detail
-
 
 class HoudiniEncoder : public prtx::GeometryEncoder {
 public:
@@ -77,16 +76,14 @@ public:
 
 private:
 	void convertGeometry(const prtx::InitialShape& initialShape,
-	                     const prtx::EncodePreparator::InstanceVector& instances,
-	                     HoudiniCallbacks* callbacks);
+	                     const prtx::EncodePreparator::InstanceVector& instances, HoudiniCallbacks* callbacks);
 };
-
 
 class HoudiniEncoderFactory : public prtx::EncoderFactory, public prtx::Singleton<HoudiniEncoderFactory> {
 public:
 	static HoudiniEncoderFactory* createInstance();
 
-	explicit HoudiniEncoderFactory(const prt::EncoderInfo* info) : prtx::EncoderFactory(info) { }
+	explicit HoudiniEncoderFactory(const prt::EncoderInfo* info) : prtx::EncoderFactory(info) {}
 	~HoudiniEncoderFactory() override = default;
 
 	HoudiniEncoder* create(const prt::AttributeMap* options, prt::Callbacks* callbacks) const override {

--- a/src/conanfile-h17.py
+++ b/src/conanfile-h17.py
@@ -18,5 +18,5 @@ class PalladioConan(ConanFile):
             if "PLD_CONAN_CESDK_VERSION" in os.environ:
                 cesdk_version = os.environ["PLD_CONAN_CESDK_VERSION"]
             else:
-                cesdk_version = "2.1.5704"
+                cesdk_version = "2.2.6332"
             self.requires("cesdk/{}@esri-rd-zurich/stable".format(cesdk_version))

--- a/src/conanfile-h17.py
+++ b/src/conanfile-h17.py
@@ -12,7 +12,7 @@ class PalladioConan(ConanFile):
         if "PLD_CONAN_HOUDINI_VERSION" in os.environ:
             self.requires("houdini/{}@sidefx/stable".format(os.environ["PLD_CONAN_HOUDINI_VERSION"]))
         else:
-            self.requires("houdini/[>17.0.0,<17.5.0]@sidefx/stable")
+            self.requires("houdini/[>17.0.0 <17.5.0]@sidefx/stable")
 
         if "PLD_CONAN_SKIP_CESDK" not in os.environ:
             if "PLD_CONAN_CESDK_VERSION" in os.environ:

--- a/src/conanfile-h175.py
+++ b/src/conanfile-h175.py
@@ -18,5 +18,5 @@ class PalladioConan(ConanFile):
             if "PLD_CONAN_CESDK_VERSION" in os.environ:
                 cesdk_version = os.environ["PLD_CONAN_CESDK_VERSION"]
             else:
-                cesdk_version = "2.1.5704"
+                cesdk_version = "2.2.6332"
             self.requires("cesdk/{}@esri-rd-zurich/stable".format(cesdk_version))

--- a/src/conanfile-h175.py
+++ b/src/conanfile-h175.py
@@ -12,7 +12,7 @@ class PalladioConan(ConanFile):
         if "PLD_CONAN_HOUDINI_VERSION" in os.environ:
             self.requires("houdini/{}@sidefx/stable".format(os.environ["PLD_CONAN_HOUDINI_VERSION"]))
         else:
-            self.requires("houdini/[>17.5.0,<18.0.0]@sidefx/stable")
+            self.requires("houdini/[>17.5.0 <18.0.0]@sidefx/stable")
 
         if "PLD_CONAN_SKIP_CESDK" not in os.environ:
             if "PLD_CONAN_CESDK_VERSION" in os.environ:

--- a/src/conanfile-h180.py
+++ b/src/conanfile-h180.py
@@ -18,5 +18,5 @@ class PalladioConan(ConanFile):
             if "PLD_CONAN_CESDK_VERSION" in os.environ:
                 cesdk_version = os.environ["PLD_CONAN_CESDK_VERSION"]
             else:
-                cesdk_version = "2.1.5704"
+                cesdk_version = "2.2.6332"
             self.requires("cesdk/{}@esri-rd-zurich/stable".format(cesdk_version))

--- a/src/conanfile-h180.py
+++ b/src/conanfile-h180.py
@@ -12,7 +12,7 @@ class PalladioConan(ConanFile):
         if "PLD_CONAN_HOUDINI_VERSION" in os.environ:
             self.requires("houdini/{}@sidefx/stable".format(os.environ["PLD_CONAN_HOUDINI_VERSION"]))
         else:
-            self.requires("houdini/[>18.0.0,<18.5.0]@sidefx/stable")
+            self.requires("houdini/[>18.0.0 <18.5.0]@sidefx/stable")
 
         if "PLD_CONAN_SKIP_CESDK" not in os.environ:
             if "PLD_CONAN_CESDK_VERSION" in os.environ:

--- a/src/dependencies.cmake
+++ b/src/dependencies.cmake
@@ -44,7 +44,7 @@ endif()
 ### run conan
 
 if(PLD_WINDOWS)
-	set(PLD_CONAN_PROFILE "${PLD_CONAN_TOOLS}/profiles/windows-v141")
+	set(PLD_CONAN_PROFILE "${PLD_CONAN_TOOLS}/profiles/windows-v142")
 elseif(PLD_LINUX)
 	set(PLD_CONAN_PROFILE "${PLD_CONAN_TOOLS}/profiles/linux-gcc63")
 endif()

--- a/src/palladio/AttrEvalCallbacks.cpp
+++ b/src/palladio/AttrEvalCallbacks.cpp
@@ -17,10 +17,9 @@
 #include "AttrEvalCallbacks.h"
 #include "LogHandler.h"
 
-
 namespace {
 
-constexpr bool           DBG                   = false;
+constexpr bool DBG = false;
 constexpr const wchar_t* CGA_ANNOTATION_HIDDEN = L"@Hidden";
 
 bool isHiddenAttribute(const RuleFileInfoUPtr& ruleFileInfo, const wchar_t* key) {
@@ -39,16 +38,17 @@ bool isHiddenAttribute(const RuleFileInfoUPtr& ruleFileInfo, const wchar_t* key)
 
 } // namespace
 
-
 prt::Status AttrEvalCallbacks::generateError(size_t isIndex, prt::Status status, const wchar_t* message) {
 	return prt::STATUS_OK;
 }
 
-prt::Status AttrEvalCallbacks::assetError(size_t isIndex, prt::CGAErrorLevel level, const wchar_t* key, const wchar_t* uri, const wchar_t* message) {
+prt::Status AttrEvalCallbacks::assetError(size_t isIndex, prt::CGAErrorLevel level, const wchar_t* key,
+                                          const wchar_t* uri, const wchar_t* message) {
 	return prt::STATUS_OK;
 }
 
-prt::Status AttrEvalCallbacks::cgaError(size_t isIndex, int32_t shapeID, prt::CGAErrorLevel level, int32_t methodId, int32_t pc, const wchar_t* message) {
+prt::Status AttrEvalCallbacks::cgaError(size_t isIndex, int32_t shapeID, prt::CGAErrorLevel level, int32_t methodId,
+                                        int32_t pc, const wchar_t* message) {
 	LOG_ERR << message;
 	return prt::STATUS_OK;
 }
@@ -65,26 +65,30 @@ prt::Status AttrEvalCallbacks::cgaReportFloat(size_t isIndex, int32_t shapeID, c
 	return prt::STATUS_OK;
 }
 
-prt::Status AttrEvalCallbacks::cgaReportString(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* value) {
+prt::Status AttrEvalCallbacks::cgaReportString(size_t isIndex, int32_t shapeID, const wchar_t* key,
+                                               const wchar_t* value) {
 	return prt::STATUS_OK;
 }
 
 prt::Status AttrEvalCallbacks::attrBool(size_t isIndex, int32_t shapeID, const wchar_t* key, bool value) {
-	if (DBG) LOG_DBG << "attrBool: isIndex = " << isIndex << ", key = " << key << " = " << value;
+	if (DBG)
+		LOG_DBG << "attrBool: isIndex = " << isIndex << ", key = " << key << " = " << value;
 	if (mRuleFileInfo[isIndex] && !isHiddenAttribute(mRuleFileInfo[isIndex], key))
 		mAMBS[isIndex]->setBool(key, value);
 	return prt::STATUS_OK;
 }
 
 prt::Status AttrEvalCallbacks::attrFloat(size_t isIndex, int32_t shapeID, const wchar_t* key, double value) {
-	if (DBG) LOG_DBG << "attrFloat: isIndex = " << isIndex << ", key = " << key << " = " << value;
+	if (DBG)
+		LOG_DBG << "attrFloat: isIndex = " << isIndex << ", key = " << key << " = " << value;
 	if (mRuleFileInfo[isIndex] && !isHiddenAttribute(mRuleFileInfo[isIndex], key))
 		mAMBS[isIndex]->setFloat(key, value);
 	return prt::STATUS_OK;
 }
 
 prt::Status AttrEvalCallbacks::attrString(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* value) {
-	if (DBG) LOG_DBG << "attrString: isIndex = " << isIndex << ", key = " << key << " = " << value;
+	if (DBG)
+		LOG_DBG << "attrString: isIndex = " << isIndex << ", key = " << key << " = " << value;
 	if (mRuleFileInfo[isIndex] && !isHiddenAttribute(mRuleFileInfo[isIndex], key))
 		mAMBS[isIndex]->setString(key, value);
 	return prt::STATUS_OK;

--- a/src/palladio/AttrEvalCallbacks.h
+++ b/src/palladio/AttrEvalCallbacks.h
@@ -22,15 +22,17 @@
 
 #include <vector>
 
-
-class AttrEvalCallbacks: public prt::Callbacks {
+class AttrEvalCallbacks : public prt::Callbacks {
 public:
-	explicit AttrEvalCallbacks(AttributeMapBuilderVector& ambs, const std::vector<RuleFileInfoUPtr>& ruleFileInfo) : mAMBS(ambs), mRuleFileInfo(ruleFileInfo) { }
+	explicit AttrEvalCallbacks(AttributeMapBuilderVector& ambs, const std::vector<RuleFileInfoUPtr>& ruleFileInfo)
+	    : mAMBS(ambs), mRuleFileInfo(ruleFileInfo) {}
 	~AttrEvalCallbacks() override = default;
 
 	prt::Status generateError(size_t isIndex, prt::Status status, const wchar_t* message) override;
-	prt::Status assetError(size_t isIndex, prt::CGAErrorLevel level, const wchar_t* key, const wchar_t* uri, const wchar_t* message) override;
-	prt::Status cgaError(size_t isIndex, int32_t shapeID, prt::CGAErrorLevel level, int32_t methodId, int32_t pc, const wchar_t* message) override;
+	prt::Status assetError(size_t isIndex, prt::CGAErrorLevel level, const wchar_t* key, const wchar_t* uri,
+	                       const wchar_t* message) override;
+	prt::Status cgaError(size_t isIndex, int32_t shapeID, prt::CGAErrorLevel level, int32_t methodId, int32_t pc,
+	                     const wchar_t* message) override;
 	prt::Status cgaPrint(size_t isIndex, int32_t shapeID, const wchar_t* txt) override;
 	prt::Status cgaReportBool(size_t isIndex, int32_t shapeID, const wchar_t* key, bool value) override;
 	prt::Status cgaReportFloat(size_t isIndex, int32_t shapeID, const wchar_t* key, double value) override;
@@ -40,13 +42,31 @@ public:
 	prt::Status attrString(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* value) override;
 
 #if (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 1)
-	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr, size_t size, size_t nRows) override { return prt::STATUS_OK; }
-	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr, size_t size, size_t nRows) override { return prt::STATUS_OK; }
-	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr, size_t size, size_t nRows) override { return prt::STATUS_OK; }
+	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr, size_t size,
+	                          size_t nRows) override {
+		return prt::STATUS_OK;
+	}
+	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr, size_t size,
+	                           size_t nRows) override {
+		return prt::STATUS_OK;
+	}
+	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr,
+	                            size_t size, size_t nRows) override {
+		return prt::STATUS_OK;
+	}
 #elif (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 0)
-	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr, size_t size) override { return prt::STATUS_OK; }
-	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr, size_t size) override { return prt::STATUS_OK; }
-	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr, size_t size) override { return prt::STATUS_OK; }
+	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr,
+	                          size_t size) override {
+		return prt::STATUS_OK;
+	}
+	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr,
+	                           size_t size) override {
+		return prt::STATUS_OK;
+	}
+	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr,
+	                            size_t size) override {
+		return prt::STATUS_OK;
+	}
 #endif
 
 private:

--- a/src/palladio/AttrEvalCallbacks.h
+++ b/src/palladio/AttrEvalCallbacks.h
@@ -39,7 +39,11 @@ public:
 	prt::Status attrFloat(size_t isIndex, int32_t shapeID, const wchar_t* key, double value) override;
 	prt::Status attrString(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* value) override;
 
-#if (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 0)
+#if (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 1)
+	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr, size_t size, size_t nRows) override { return prt::STATUS_OK; }
+	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr, size_t size, size_t nRows) override { return prt::STATUS_OK; }
+	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr, size_t size, size_t nRows) override { return prt::STATUS_OK; }
+#elif (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 0)
 	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr, size_t size) override { return prt::STATUS_OK; }
 	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr, size_t size) override { return prt::STATUS_OK; }
 	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr, size_t size) override { return prt::STATUS_OK; }

--- a/src/palladio/AttributeConversion.cpp
+++ b/src/palladio/AttributeConversion.cpp
@@ -113,7 +113,7 @@ void setHandleRange(const GA_IndexMap& indexMap, GA_RWHandleIA& handle, GA_Offse
 	for (GA_Offset off = start; off < start + size; off++)
 		handle.set(off, hv);
 	if (DBG)
-		LOG_DBG << "int array attr: range = [" << start << ", " << start + size
+		LOG_DBG << "bool array attr: range = [" << start << ", " << start + size
 		        << "): " << handle.getAttribute()->getName() << " = " << hv;
 }
 
@@ -125,7 +125,7 @@ void setHandleRange(const GA_IndexMap& indexMap, GA_RWHandleSA& handle, GA_Offse
 	for (GA_Offset off = start; off < start + size; off++)
 		handle.set(off, hv);
 	if (DBG)
-		LOG_DBG << "int array attr: range = [" << start << ", " << start + size
+		LOG_DBG << "string array attr: range = [" << start << ", " << start + size
 		        << "): " << handle.getAttribute()->getName() << " = " << hv;
 }
 

--- a/src/palladio/AttributeConversion.cpp
+++ b/src/palladio/AttributeConversion.cpp
@@ -19,8 +19,10 @@
 #include "LogHandler.h"
 #include "MultiWatch.h"
 
+// clang-format off
 #include "BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/algorithm/string.hpp)
+// clang-format on
 
 #include <mutex>
 #include <bitset>

--- a/src/palladio/AttributeConversion.cpp
+++ b/src/palladio/AttributeConversion.cpp
@@ -375,6 +375,14 @@ void setAttributeValues(HandleMap& handleMap, const prt::AttributeMap* attrMap, 
 	}
 }
 
+void convertAttributes(GU_Detail* detail, HandleMap& handleMap, const prt::AttributeMap* attrMap,
+                       const GA_Offset rangeStart, const GA_Size rangeSize, ArrayHandling arrayHandling) {
+	const GA_IndexMap& primIndexMap = detail->getIndexMap(GA_ATTRIB_PRIMITIVE);
+	extractAttributeNames(handleMap, attrMap);
+	createAttributeHandles(detail, handleMap, arrayHandling == ArrayHandling::ARRAY);
+	setAttributeValues(handleMap, attrMap, primIndexMap, rangeStart, rangeSize);
+}
+
 } // namespace AttributeConversion
 
 namespace {

--- a/src/palladio/AttributeConversion.cpp
+++ b/src/palladio/AttributeConversion.cpp
@@ -35,11 +35,6 @@ namespace StringConversionCaches {
 LockedLRUCache<std::wstring, UT_String> toPrimAttr(1 << 12);
 }
 
-template <typename H, typename V>
-void setHandleRange(const GA_IndexMap& indexMap, H& handle, GA_Offset start, GA_Size size, int component,
-                    const V& value);
-
-template <>
 void setHandleRange(const GA_IndexMap& indexMap, GA_RWHandleC& handle, GA_Offset start, GA_Size size, int component,
                     const bool& value) {
 	constexpr int8_t valFalse = 0;
@@ -51,7 +46,6 @@ void setHandleRange(const GA_IndexMap& indexMap, GA_RWHandleC& handle, GA_Offset
 		        << " = " << value;
 }
 
-template <>
 void setHandleRange(const GA_IndexMap& indexMap, GA_RWHandleI& handle, GA_Offset start, GA_Size size, int component,
                     const int32_t& value) {
 	handle.setBlock(start, size, &value, 0, component);
@@ -60,7 +54,6 @@ void setHandleRange(const GA_IndexMap& indexMap, GA_RWHandleI& handle, GA_Offset
 		        << " = " << value;
 }
 
-template <>
 void setHandleRange(const GA_IndexMap& indexMap, GA_RWHandleF& handle, GA_Offset start, GA_Size size, int component,
                     const double& value) {
 	const auto hv = static_cast<fpreal32>(value);
@@ -70,7 +63,6 @@ void setHandleRange(const GA_IndexMap& indexMap, GA_RWHandleF& handle, GA_Offset
 		        << "): " << handle.getAttribute()->getName() << " = " << value;
 }
 
-template <>
 void setHandleRange(const GA_IndexMap& indexMap, GA_RWBatchHandleS& handle, GA_Offset start, GA_Size size,
                     int component, const std::wstring& value) {
 	const UT_String attrValue = [&value]() {

--- a/src/palladio/AttributeConversion.h
+++ b/src/palladio/AttributeConversion.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "LogHandler.h"
 #include "PalladioMain.h"
 #include "Utils.h"
 
@@ -38,6 +39,151 @@ struct hash<UT_String> {
 } // namespace std
 
 namespace AttributeConversion {
+
+class FromHoudini {
+private:
+	static const bool DBG = true;
+
+public:
+	FromHoudini(prt::AttributeMapBuilder& builder) : mBuilder(builder) {}
+
+	bool convert(const GA_ROAttributeRef& ar, const GA_Offset& offset, const std::wstring& name) {
+		if (isArrayAttribute(ar))
+			return handleArray(ar, offset, name);
+		else
+			return handleScalar(ar, offset, name);
+	}
+
+private:
+	bool handleScalar(const GA_ROAttributeRef& ar, const GA_Offset& offset, const std::wstring& name) {
+		bool conversionResult = true;
+		switch (ar.getStorageClass()) {
+			case GA_STORECLASS_FLOAT: {
+				GA_ROHandleD av(ar);
+				if (av.isValid()) {
+					double v = av.get(offset);
+					if (DBG)
+						LOG_DBG << "   prim float attr: " << ar->getName() << " = " << v;
+					mBuilder.setFloat(name.c_str(), v);
+				}
+				break;
+			}
+			case GA_STORECLASS_STRING: {
+				GA_ROHandleS av(ar);
+				if (av.isValid()) {
+					const char* v = av.get(offset);
+					const std::wstring wv = toUTF16FromOSNarrow(v);
+					if (DBG)
+						LOG_DBG << "   prim string attr: " << ar->getName() << " = " << v;
+					mBuilder.setString(name.c_str(), wv.c_str());
+				}
+				break;
+			}
+			case GA_STORECLASS_INT: {
+				if (ar.getAIFTuple()->getStorage(ar.get()) == GA_STORE_INT8) {
+					GA_ROHandleI av(ar);
+					if (av.isValid()) {
+						const int v = av.get(offset);
+						const bool bv = (v > 0);
+						if (DBG)
+							LOG_DBG << "   prim bool attr: " << ar->getName() << " = " << bv;
+						mBuilder.setBool(name.c_str(), bv);
+					}
+				}
+				else {
+					GA_ROHandleI av(ar);
+					if (av.isValid()) {
+						const int v = av.get(offset);
+						if (DBG)
+							LOG_DBG << "   prim int attr: " << ar->getName() << " = " << v;
+						mBuilder.setInt(name.c_str(), v);
+					}
+				}
+				break;
+			}
+			default: {
+				LOG_WRN << "prim attr " << ar->getName() << ": unsupported storage class";
+				conversionResult = false;
+				break;
+			}
+		}
+		return conversionResult;
+	}
+
+	bool handleArray(const GA_ROAttributeRef& ar, const GA_Offset& offset, const std::wstring& name) {
+		bool conversionResult = true;
+		switch (ar.getStorageClass()) {
+			case GA_STORECLASS_FLOAT: {
+				GA_ROHandleDA av(ar);
+				if (av.isValid()) {
+					UT_Fpreal64Array v;
+					av.get(offset, v);
+					if (DBG)
+						LOG_DBG << "   prim float array attr: " << ar->getName() << " = " << v;
+					mBuilder.setFloatArray(name.c_str(), v.data(), v.size());
+				}
+				break;
+			}
+			case GA_STORECLASS_STRING: {
+				GA_ROHandleSA av(ar);
+				if (av.isValid()) {
+					UT_StringArray v;
+					av.get(offset, v);
+					if (DBG)
+						LOG_DBG << "   prim string array attr: " << ar->getName() << " = " << v;
+
+					std::vector<std::wstring> wstrings(v.size());
+					std::vector<const wchar_t*> wstringPtrs(v.size());
+					for (size_t i = 0; i < v.size(); i++) {
+						wstrings[i] = toUTF16FromOSNarrow(v[i].toStdString());
+						wstringPtrs[i] = wstrings[i].c_str();
+					}
+					mBuilder.setStringArray(name.c_str(), wstringPtrs.data(), wstringPtrs.size());
+				}
+				break;
+			}
+			case GA_STORECLASS_INT: {
+				if (ar.getAIFNumericArray()->getStorage(ar.get()) == GA_STORE_INT8) {
+					GA_ROHandleIA av(ar);
+					if (av.isValid()) {
+						UT_Int32Array v; // there is no U_Int8Array
+						av.get(offset, v);
+						if (DBG)
+							LOG_DBG << "   prim bool array attr: " << ar->getName() << " = " << v;
+						const std::unique_ptr<bool[]> vPtrs(new bool[v.size()]);
+						for (size_t i = 0; i < v.size(); i++)
+							vPtrs[i] = (v[i] > 0);
+						mBuilder.setBoolArray(name.c_str(), vPtrs.get(), v.size());
+					}
+				}
+				else {
+					GA_ROHandleIA av(ar);
+					if (av.isValid()) {
+						UT_Int32Array v;
+						av.get(offset, v);
+						if (DBG)
+							LOG_DBG << "   prim int array attr: " << ar->getName() << " = " << v;
+						mBuilder.setIntArray(name.c_str(), v.data(), v.size());
+					}
+				}
+				break;
+			}
+			default: {
+				LOG_WRN << "prim attr " << ar->getName() << ": unsupported storage class";
+				conversionResult = false;
+				break;
+			}
+		}
+		return conversionResult;
+	}
+
+	bool isArrayAttribute(const GA_ROAttributeRef& ar) {
+		return (ar.getAIFNumericArray() != nullptr) || (ar.getAIFSharedStringArray() != nullptr);
+	}
+
+private:
+	prt::AttributeMapBuilder& mBuilder;
+};
 
 /**
  * attribute type conversion from PRT to Houdini:

--- a/src/palladio/AttributeConversion.h
+++ b/src/palladio/AttributeConversion.h
@@ -21,8 +21,10 @@
 
 #include "GU/GU_Detail.h"
 
+// clang-format off
 #include "BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/variant.hpp)
+// clang-format on
 
 #include <unordered_map>
 

--- a/src/palladio/AttributeConversion.h
+++ b/src/palladio/AttributeConversion.h
@@ -28,15 +28,14 @@
 
 #include <unordered_map>
 
-
 namespace std {
-    template<> struct hash<UT_String> {
-        std::size_t operator()(UT_String const& s) const noexcept {
-            return s.hash();
-        }
-    };
-}
-
+template <>
+struct hash<UT_String> {
+	std::size_t operator()(UT_String const& s) const noexcept {
+		return s.hash();
+	}
+};
+} // namespace std
 
 namespace AttributeConversion {
 
@@ -47,28 +46,25 @@ namespace AttributeConversion {
  * bool    -> int8_t
  * double  -> float (single precision!)
  */
-using NoHandle   = int8_t;
+using NoHandle = int8_t;
 using HandleType = PLD_BOOST_NS::variant<NoHandle, GA_RWBatchHandleS, GA_RWHandleI, GA_RWHandleC, GA_RWHandleF>;
-
 
 // bound to life time of PRT attribute map
 struct ProtoHandle {
-	HandleType                       handleType;
-	std::wstring                     key;
+	HandleType handleType;
+	std::wstring key;
 	prt::AttributeMap::PrimitiveType type; // original PRT type
-	size_t                           cardinality;
+	size_t cardinality;
 };
 
 using HandleMap = std::unordered_map<UT_StringHolder, ProtoHandle>;
 
 PLD_TEST_EXPORTS_API void extractAttributeNames(HandleMap& handleMap, const prt::AttributeMap* attrMap);
 void createAttributeHandles(GU_Detail* detail, HandleMap& handleMap);
-void setAttributeValues(HandleMap& handleMap, const prt::AttributeMap* attrMap,
-                        const GA_IndexMap& primIndexMap, const GA_Offset rangeStart,
-                        const GA_Size rangeSize);
+void setAttributeValues(HandleMap& handleMap, const prt::AttributeMap* attrMap, const GA_IndexMap& primIndexMap,
+                        const GA_Offset rangeStart, const GA_Size rangeSize);
 
 } // namespace AttributeConversion
-
 
 namespace NameConversion {
 

--- a/src/palladio/AttributeConversion.h
+++ b/src/palladio/AttributeConversion.h
@@ -60,10 +60,10 @@ struct ProtoHandle {
 
 using HandleMap = std::unordered_map<UT_StringHolder, ProtoHandle>;
 
-PLD_TEST_EXPORTS_API void extractAttributeNames(HandleMap& handleMap, const prt::AttributeMap* attrMap);
-void createAttributeHandles(GU_Detail* detail, HandleMap& handleMap, bool useArrayTypes = false);
-void setAttributeValues(HandleMap& handleMap, const prt::AttributeMap* attrMap, const GA_IndexMap& primIndexMap,
-                        const GA_Offset rangeStart, const GA_Size rangeSize);
+enum class ArrayHandling { TUPLE, ARRAY };
+void convertAttributes(GU_Detail* detail, HandleMap& handleMap, const prt::AttributeMap* attrMap,
+                       const GA_Offset rangeStart, const GA_Size rangeSize,
+                       ArrayHandling arrayHandling = ArrayHandling::TUPLE);
 
 } // namespace AttributeConversion
 

--- a/src/palladio/AttributeConversion.h
+++ b/src/palladio/AttributeConversion.h
@@ -47,7 +47,8 @@ namespace AttributeConversion {
  * double  -> float (single precision!)
  */
 using NoHandle = int8_t;
-using HandleType = PLD_BOOST_NS::variant<NoHandle, GA_RWBatchHandleS, GA_RWHandleI, GA_RWHandleC, GA_RWHandleF>;
+using HandleType = PLD_BOOST_NS::variant<NoHandle, GA_RWBatchHandleS, GA_RWHandleI, GA_RWHandleC, GA_RWHandleF,
+                                         GA_RWHandleSA, GA_RWHandleIA, GA_RWHandleDA>;
 
 // bound to life time of PRT attribute map
 struct ProtoHandle {
@@ -60,7 +61,7 @@ struct ProtoHandle {
 using HandleMap = std::unordered_map<UT_StringHolder, ProtoHandle>;
 
 PLD_TEST_EXPORTS_API void extractAttributeNames(HandleMap& handleMap, const prt::AttributeMap* attrMap);
-void createAttributeHandles(GU_Detail* detail, HandleMap& handleMap);
+void createAttributeHandles(GU_Detail* detail, HandleMap& handleMap, bool useArrayTypes = false);
 void setAttributeValues(HandleMap& handleMap, const prt::AttributeMap* attrMap, const GA_IndexMap& primIndexMap,
                         const GA_Offset rangeStart, const GA_Size rangeSize);
 

--- a/src/palladio/BoostRedirect.h
+++ b/src/palladio/BoostRedirect.h
@@ -16,7 +16,9 @@
 
 #pragma once
 
+// clang-format off
 #define PLD_STRINGIFY(x) PLD_STR(x)
 #define PLD_STR(x) #x
 #define PLD_EXPAND(x) x
 #define PLD_BOOST_INCLUDE(p) PLD_STRINGIFY(PLD_EXPAND(PLD_BOOST_NS)PLD_EXPAND(p))
+// clang-format on

--- a/src/palladio/CMakeLists.txt
+++ b/src/palladio/CMakeLists.txt
@@ -37,6 +37,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 ### compiler settings
 
 add_toolchain_definition(${PROJECT_NAME})
+pld_add_version_definitions(${PROJECT_NAME})
 
 if(PLD_TEST)
 	message(STATUS "Enabling test exports...")

--- a/src/palladio/LRUCache.h
+++ b/src/palladio/LRUCache.h
@@ -1,4 +1,4 @@
-# pragma once
+#pragma once
 
 // clang-format off
 #include "BoostRedirect.h"
@@ -8,7 +8,6 @@
 #include <list>
 #include <map>
 #include <mutex>
-
 
 // shamelessly copied from boost (houdini's hboost does not include this header)
 // http://www.boost.org/doc/libs/1_66_0/boost/compute/detail/lru_cache.hpp
@@ -24,116 +23,98 @@
 //---------------------------------------------------------------------------//
 
 // a cache which evicts the least recently used item when it is full
-template<class Key, class Value>
-class lru_cache
-{
+template <class Key, class Value>
+class lru_cache {
 public:
-    typedef Key key_type;
-    typedef Value value_type;
-    typedef std::list<key_type> list_type;
-    typedef std::map<
-                key_type,
-                std::pair<value_type, typename list_type::iterator>
-            > map_type;
+	typedef Key key_type;
+	typedef Value value_type;
+	typedef std::list<key_type> list_type;
+	typedef std::map<key_type, std::pair<value_type, typename list_type::iterator>> map_type;
 
-    lru_cache(size_t capacity)
-        : m_capacity(capacity)
-    {
-    }
+	lru_cache(size_t capacity) : m_capacity(capacity) {}
 
-    ~lru_cache()
-    {
-    }
+	~lru_cache() {}
 
-    size_t size() const
-    {
-        return m_map.size();
-    }
+	size_t size() const {
+		return m_map.size();
+	}
 
-    size_t capacity() const
-    {
-        return m_capacity;
-    }
+	size_t capacity() const {
+		return m_capacity;
+	}
 
-    bool empty() const
-    {
-        return m_map.empty();
-    }
+	bool empty() const {
+		return m_map.empty();
+	}
 
-    bool contains(const key_type &key)
-    {
-        return m_map.find(key) != m_map.end();
-    }
+	bool contains(const key_type& key) {
+		return m_map.find(key) != m_map.end();
+	}
 
-    void insert(const key_type &key, const value_type &value)
-    {
-        typename map_type::iterator i = m_map.find(key);
-        if(i == m_map.end()){
-            // insert item into the mCache, but first check if it is full
-            if(size() >= m_capacity){
-                // mCache is full, evict the least recently used item
-                evict();
-            }
+	void insert(const key_type& key, const value_type& value) {
+		typename map_type::iterator i = m_map.find(key);
+		if (i == m_map.end()) {
+			// insert item into the mCache, but first check if it is full
+			if (size() >= m_capacity) {
+				// mCache is full, evict the least recently used item
+				evict();
+			}
 
-            // insert the new item
-            m_list.push_front(key);
-            m_map[key] = std::make_pair(value, m_list.begin());
-        }
-    }
+			// insert the new item
+			m_list.push_front(key);
+			m_map[key] = std::make_pair(value, m_list.begin());
+		}
+	}
 
-    PLD_BOOST_NS::optional<value_type> get(const key_type &key)
-    {
-        // lookup value in the mCache
-        typename map_type::iterator i = m_map.find(key);
-        if(i == m_map.end()){
-            // value not in mCache
-            return PLD_BOOST_NS::none;
-        }
+	PLD_BOOST_NS::optional<value_type> get(const key_type& key) {
+		// lookup value in the mCache
+		typename map_type::iterator i = m_map.find(key);
+		if (i == m_map.end()) {
+			// value not in mCache
+			return PLD_BOOST_NS::none;
+		}
 
-        // return the value, but first update its place in the most
-        // recently used list
-        typename list_type::iterator j = i->second.second;
-        if(j != m_list.begin()){
-            // move item to the front of the most recently used list
-            m_list.erase(j);
-            m_list.push_front(key);
+		// return the value, but first update its place in the most
+		// recently used list
+		typename list_type::iterator j = i->second.second;
+		if (j != m_list.begin()) {
+			// move item to the front of the most recently used list
+			m_list.erase(j);
+			m_list.push_front(key);
 
-            // update iterator in map
-            j = m_list.begin();
-            const value_type &value = i->second.first;
-            m_map[key] = std::make_pair(value, j);
+			// update iterator in map
+			j = m_list.begin();
+			const value_type& value = i->second.first;
+			m_map[key] = std::make_pair(value, j);
 
-            // return the value
-            return value;
-        }
-        else {
-            // the item is already at the front of the most recently
-            // used list so just return it
-            return i->second.first;
-        }
-    }
+			// return the value
+			return value;
+		}
+		else {
+			// the item is already at the front of the most recently
+			// used list so just return it
+			return i->second.first;
+		}
+	}
 
-    void clear()
-    {
-        m_map.clear();
-        m_list.clear();
-    }
+	void clear() {
+		m_map.clear();
+		m_list.clear();
+	}
 
 private:
-    void evict()
-    {
-        // evict item from the end of most recently used list
-        typename list_type::iterator i = --m_list.end();
-        m_map.erase(*i);
-        m_list.erase(i);
-    }
+	void evict() {
+		// evict item from the end of most recently used list
+		typename list_type::iterator i = --m_list.end();
+		m_map.erase(*i);
+		m_list.erase(i);
+	}
 
 private:
-    map_type m_map;
-    list_type m_list;
-    size_t m_capacity;
+	map_type m_map;
+	list_type m_list;
+	size_t m_capacity;
 };
-
 
 /*
  * Copyright 2014-2019 Esri R&D Zurich and VRBN
@@ -153,12 +134,12 @@ private:
 
 #undef LOCKED_LRU_CACHE_STATS
 
-template<typename K, typename V>
-class LockedLRUCache : public lru_cache<K,V> {
+template <typename K, typename V>
+class LockedLRUCache : public lru_cache<K, V> {
 private:
-	using Base = lru_cache<K,V>;
+	using Base = lru_cache<K, V>;
 
-    std::mutex mMutex;
+	std::mutex mMutex;
 
 #ifdef LOCKED_LRU_CACHE_STATS
 	size_t hits = 0;
@@ -166,30 +147,31 @@ private:
 #endif
 
 public:
-	LockedLRUCache(size_t capacity) : Base{capacity} { }
+	LockedLRUCache(size_t capacity) : Base{capacity} {}
 
 	~LockedLRUCache() {
 #ifdef LOCKED_LRU_CACHE_STATS
-		std::wcout << L"~LockedLRUCache: capacity = " << this->capacity() << L", size = " << this->size() << L", hits = " << hits << L", misses = " << misses << std::endl;
+		std::wcout << L"~LockedLRUCache: capacity = " << this->capacity() << L", size = " << this->size()
+		           << L", hits = " << hits << L", misses = " << misses << std::endl;
 #endif
 	}
 
-    void insert(const K& key, const V& value) {
+	void insert(const K& key, const V& value) {
 		std::lock_guard<std::mutex> guard(mMutex);
-        Base::insert(key, value);
-    }
+		Base::insert(key, value);
+	}
 
-    PLD_BOOST_NS::optional<V> get(const K& key) {
+	PLD_BOOST_NS::optional<V> get(const K& key) {
 		std::lock_guard<std::mutex> guard(mMutex);
-        auto v = Base::get(key);
+		auto v = Base::get(key);
 
 #ifdef LOCKED_LRU_CACHE_STATS
 		if (v)
 			hits++;
-        else
-            misses++;
+		else
+			misses++;
 #endif
 
-        return v;
-    }
+		return v;
+	}
 };

--- a/src/palladio/LRUCache.h
+++ b/src/palladio/LRUCache.h
@@ -1,7 +1,9 @@
 # pragma once
 
+// clang-format off
 #include "BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/optional.hpp)
+// clang-format on
 
 #include <list>
 #include <map>

--- a/src/palladio/LogHandler.h
+++ b/src/palladio/LogHandler.h
@@ -19,58 +19,84 @@
 #include "prt/API.h"
 #include "prt/LogHandler.h"
 
-#include <string>
-#include <vector>
+#include <iostream>
 #include <iterator>
+#include <memory>
 #include <ostream>
 #include <sstream>
-#include <iostream>
-#include <memory>
-
+#include <string>
+#include <vector>
 
 namespace logging {
 
-struct Logger { };
+struct Logger {};
 
-const std::string LEVELS[] = { "trace", "debug", "info", "warning", "error", "fatal" };
-const std::wstring WLEVELS[] = { L"trace", L"debug", L"info", L"warning", L"error", L"fatal" };
+const std::string LEVELS[] = {"trace", "debug", "info", "warning", "error", "fatal"};
+const std::wstring WLEVELS[] = {L"trace", L"debug", L"info", L"warning", L"error", L"fatal"};
 
 // log to std streams
-template<prt::LogLevel L> struct StreamLogger : Logger {
-	StreamLogger(std::wostream& out = std::wcout) : Logger(), mOut(out) { mOut << prefix(); }
-	virtual ~StreamLogger() { mOut << std::endl; }
-	StreamLogger<L>& operator<<(std::wostream&(*x)(std::wostream&)) { mOut << x; return *this; }
-	StreamLogger<L>& operator<<(const std::string& x) { std::copy(x.begin(), x.end(), std::ostream_iterator<char, wchar_t>(mOut)); return *this; }
-	template<typename T> StreamLogger<L>& operator<<(const T& x) { mOut << x; return *this; }
-	static std::wstring prefix() { return L"[" + WLEVELS[L] + L"] "; }
+template <prt::LogLevel L>
+struct StreamLogger : Logger {
+	StreamLogger(std::wostream& out = std::wcout) : Logger(), mOut(out) {
+		mOut << prefix();
+	}
+	virtual ~StreamLogger() {
+		mOut << std::endl;
+	}
+	StreamLogger<L>& operator<<(std::wostream& (*x)(std::wostream&)) {
+		mOut << x;
+		return *this;
+	}
+	StreamLogger<L>& operator<<(const std::string& x) {
+		std::copy(x.begin(), x.end(), std::ostream_iterator<char, wchar_t>(mOut));
+		return *this;
+	}
+	template <typename T>
+	StreamLogger<L>& operator<<(const T& x) {
+		mOut << x;
+		return *this;
+	}
+	static std::wstring prefix() {
+		return L"[" + WLEVELS[L] + L"] ";
+	}
 	std::wostream& mOut;
 };
 
 // log through the prt logger
-template<prt::LogLevel L> struct PRTLogger : Logger {
-	PRTLogger() : Logger() { }
-	virtual ~PRTLogger() { prt::log(wstr.str().c_str(), L); }
-	PRTLogger<L>& operator<<(std::wostream&(*x)(std::wostream&)) { wstr << x;  return *this; }
+template <prt::LogLevel L>
+struct PRTLogger : Logger {
+	PRTLogger() : Logger() {}
+	virtual ~PRTLogger() {
+		prt::log(wstr.str().c_str(), L);
+	}
+	PRTLogger<L>& operator<<(std::wostream& (*x)(std::wostream&)) {
+		wstr << x;
+		return *this;
+	}
 	PRTLogger<L>& operator<<(const std::string& x) {
 		std::copy(x.begin(), x.end(), std::ostream_iterator<char, wchar_t>(wstr));
 		return *this;
 	}
-	template<typename T> PRTLogger<L>& operator<<(const std::vector<T>& v) {
+	template <typename T>
+	PRTLogger<L>& operator<<(const std::vector<T>& v) {
 		wstr << L"[ ";
-		for (const T& x: v) {
+		for (const T& x : v) {
 			wstr << x << L" ";
 		}
 		wstr << L"]";
 		return *this;
 	}
-	template<typename T> PRTLogger<L>& operator<<(const T& x) { wstr << x; return *this; }
+	template <typename T>
+	PRTLogger<L>& operator<<(const T& x) {
+		wstr << x;
+		return *this;
+	}
 	std::wostringstream wstr;
 };
 
 class LogHandler : public prt::LogHandler {
 public:
-	LogHandler(const std::wstring& name) : mName(name) {
-	}
+	LogHandler(const std::wstring& name) : mName(name) {}
 
 	virtual void handleLogEvent(const wchar_t* msg, prt::LogLevel level) override {
 		// probably not the best idea - is there a houdini logging framework?
@@ -98,10 +124,10 @@ private:
 using LogHandlerPtr = std::unique_ptr<LogHandler>;
 
 // switch logger here between PRTLogger and StreamLogger
-template<prt::LogLevel L>
+template <prt::LogLevel L>
 using LT = PRTLogger<L>;
 
-} // namespace log
+} // namespace logging
 
 using _LOG_DBG = logging::LT<prt::LOG_DEBUG>;
 using _LOG_INF = logging::LT<prt::LOG_INFO>;

--- a/src/palladio/LogHandler.h
+++ b/src/palladio/LogHandler.h
@@ -97,17 +97,17 @@ private:
 
 using LogHandlerPtr = std::unique_ptr<LogHandler>;
 
+// switch logger here between PRTLogger and StreamLogger
+template<prt::LogLevel L>
+using LT = PRTLogger<L>;
+
 } // namespace log
 
-
-// switch logger here
-#define LT logging::PRTLogger
-
-using _LOG_DBG = LT<prt::LOG_DEBUG>;
-using _LOG_INF = LT<prt::LOG_INFO>;
-using _LOG_WRN = LT<prt::LOG_WARNING>;
-using _LOG_ERR = LT<prt::LOG_ERROR>;
-using _LOG_FTL = LT<prt::LOG_FATAL>;
+using _LOG_DBG = logging::LT<prt::LOG_DEBUG>;
+using _LOG_INF = logging::LT<prt::LOG_INFO>;
+using _LOG_WRN = logging::LT<prt::LOG_WARNING>;
+using _LOG_ERR = logging::LT<prt::LOG_ERROR>;
+using _LOG_FTL = logging::LT<prt::LOG_FATAL>;
 
 // convenience shortcuts in global namespace
 #define LOG_DBG _LOG_DBG() << __FUNCTION__ << ": "

--- a/src/palladio/ModelConverter.cpp
+++ b/src/palladio/ModelConverter.cpp
@@ -203,7 +203,7 @@ void ModelConverter::add(const wchar_t* name, const double* vtx, size_t vtxSize,
 				if (it != mShapeAttributeBuilders.end()) {
 					const AttributeMapUPtr attrMap(it->second->createAttributeMap());
 					AttributeConversion::extractAttributeNames(handleMap, attrMap.get());
-					AttributeConversion::createAttributeHandles(mDetail, handleMap);
+					AttributeConversion::createAttributeHandles(mDetail, handleMap, true);
 					AttributeConversion::setAttributeValues(handleMap, attrMap.get(), primIndexMap, rangeStart,
 					                                        rangeSize);
 				}

--- a/src/palladio/ModelConverter.cpp
+++ b/src/palladio/ModelConverter.cpp
@@ -176,17 +176,17 @@ void ModelConverter::add(const wchar_t* name, const double* vtx, size_t vtxSize,
 	if (faceRangesSize > 1) {
 		WA("add materials/reports");
 
-		AttributeConversion::HandleMap handleMap;
+		AttributeConversion::ToHoudini toHoudini(mDetail);
 		for (size_t fri = 0; fri < faceRangesSize - 1; fri++) {
 			const GA_Offset rangeStart = primStartOffset + faceRanges[fri];
 			const GA_Size rangeSize = faceRanges[fri + 1] - faceRanges[fri];
 
 			if (materials != nullptr) {
-				AttributeConversion::convertAttributes(mDetail, handleMap, materials[fri], rangeStart, rangeSize);
+				toHoudini.convert(materials[fri], rangeStart, rangeSize);
 			}
 
 			if (reports != nullptr) {
-				AttributeConversion::convertAttributes(mDetail, handleMap, reports[fri], rangeStart, rangeSize);
+				toHoudini.convert(reports[fri], rangeStart, rangeSize);
 			}
 
 			if (!mShapeAttributeBuilders.empty()) {
@@ -195,8 +195,8 @@ void ModelConverter::add(const wchar_t* name, const double* vtx, size_t vtxSize,
 				auto it = mShapeAttributeBuilders.find(shapeID);
 				if (it != mShapeAttributeBuilders.end()) {
 					const AttributeMapUPtr attrMap(it->second->createAttributeMap());
-					AttributeConversion::convertAttributes(mDetail, handleMap, attrMap.get(), rangeStart, rangeSize,
-					                                       AttributeConversion::ArrayHandling::ARRAY);
+					toHoudini.convert(attrMap.get(), rangeStart, rangeSize,
+					                  AttributeConversion::ToHoudini::ArrayHandling::ARRAY);
 				}
 			}
 		}

--- a/src/palladio/ModelConverter.cpp
+++ b/src/palladio/ModelConverter.cpp
@@ -22,8 +22,10 @@
 
 #include "GU/GU_HoleInfo.h"
 
+// clang-format off
 #include "BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/variant.hpp)
+// clang-format on
 
 #include <mutex>
 

--- a/src/palladio/ModelConverter.cpp
+++ b/src/palladio/ModelConverter.cpp
@@ -177,23 +177,16 @@ void ModelConverter::add(const wchar_t* name, const double* vtx, size_t vtxSize,
 		WA("add materials/reports");
 
 		AttributeConversion::HandleMap handleMap;
-		const GA_IndexMap& primIndexMap = mDetail->getIndexMap(GA_ATTRIB_PRIMITIVE);
 		for (size_t fri = 0; fri < faceRangesSize - 1; fri++) {
 			const GA_Offset rangeStart = primStartOffset + faceRanges[fri];
 			const GA_Size rangeSize = faceRanges[fri + 1] - faceRanges[fri];
 
 			if (materials != nullptr) {
-				const prt::AttributeMap* attrMap = materials[fri];
-				AttributeConversion::extractAttributeNames(handleMap, attrMap);
-				AttributeConversion::createAttributeHandles(mDetail, handleMap);
-				AttributeConversion::setAttributeValues(handleMap, attrMap, primIndexMap, rangeStart, rangeSize);
+				AttributeConversion::convertAttributes(mDetail, handleMap, materials[fri], rangeStart, rangeSize);
 			}
 
 			if (reports != nullptr) {
-				const prt::AttributeMap* attrMap = reports[fri];
-				AttributeConversion::extractAttributeNames(handleMap, attrMap);
-				AttributeConversion::createAttributeHandles(mDetail, handleMap);
-				AttributeConversion::setAttributeValues(handleMap, attrMap, primIndexMap, rangeStart, rangeSize);
+				AttributeConversion::convertAttributes(mDetail, handleMap, reports[fri], rangeStart, rangeSize);
 			}
 
 			if (!mShapeAttributeBuilders.empty()) {
@@ -202,10 +195,8 @@ void ModelConverter::add(const wchar_t* name, const double* vtx, size_t vtxSize,
 				auto it = mShapeAttributeBuilders.find(shapeID);
 				if (it != mShapeAttributeBuilders.end()) {
 					const AttributeMapUPtr attrMap(it->second->createAttributeMap());
-					AttributeConversion::extractAttributeNames(handleMap, attrMap.get());
-					AttributeConversion::createAttributeHandles(mDetail, handleMap, true);
-					AttributeConversion::setAttributeValues(handleMap, attrMap.get(), primIndexMap, rangeStart,
-					                                        rangeSize);
+					AttributeConversion::convertAttributes(mDetail, handleMap, attrMap.get(), rangeStart, rangeSize,
+					                                       AttributeConversion::ArrayHandling::ARRAY);
 				}
 			}
 		}

--- a/src/palladio/ModelConverter.cpp
+++ b/src/palladio/ModelConverter.cpp
@@ -278,3 +278,32 @@ prt::Status ModelConverter::attrString(size_t isIndex, int32_t shapeID, const wc
 	getBuilder(mShapeAttributeBuilders, shapeID)->setString(key, value);
 	return prt::STATUS_OK;
 }
+
+#if (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 1)
+
+prt::Status ModelConverter::attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr,
+                                          size_t size, size_t nRows) {
+	if (DBG)
+		LOG_DBG << "attrBoolArray: shapeID :" << shapeID << ", key: " << key << ", val: " << ptr << ", size: " << size;
+	getBuilder(mShapeAttributeBuilders, shapeID)->setBoolArray(key, ptr, size);
+	return prt::STATUS_OK;
+}
+
+prt::Status ModelConverter::attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr,
+                                           size_t size, size_t nRows) {
+	if (DBG)
+		LOG_DBG << "attrFloatArray: shapeID :" << shapeID << ", key: " << key << ", val: " << ptr << ", size: " << size;
+	getBuilder(mShapeAttributeBuilders, shapeID)->setFloatArray(key, ptr, size);
+	return prt::STATUS_OK;
+}
+
+prt::Status ModelConverter::attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key,
+                                            const wchar_t* const* ptr, size_t size, size_t nRows) {
+	if (DBG)
+		LOG_DBG << "attrStringArray: shapeID :" << shapeID << ", key: " << key << ", val: " << ptr
+		        << ", size: " << size;
+	getBuilder(mShapeAttributeBuilders, shapeID)->setStringArray(key, ptr, size);
+	return prt::STATUS_OK;
+}
+
+#endif

--- a/src/palladio/ModelConverter.cpp
+++ b/src/palladio/ModelConverter.cpp
@@ -16,9 +16,9 @@
 
 #include "ModelConverter.h"
 #include "AttributeConversion.h"
-#include "ShapeConverter.h"
 #include "LogHandler.h"
 #include "MultiWatch.h"
+#include "ShapeConverter.h"
 
 #include "GU/GU_HoleInfo.h"
 
@@ -28,7 +28,6 @@
 // clang-format on
 
 #include <mutex>
-
 
 namespace {
 
@@ -48,14 +47,12 @@ UTVector3FVector convertVertices(const double* vtx, size_t vtxSize) {
 	return utPoints;
 }
 
-void setVertexNormals(
-	GA_RWHandleV3& handle, const GA_Detail::OffsetMarker& marker,
-	const double* nrm, size_t nrmSize, const uint32_t* indices
-) {
+void setVertexNormals(GA_RWHandleV3& handle, const GA_Detail::OffsetMarker& marker, const double* nrm, size_t nrmSize,
+                      const uint32_t* indices) {
 	uint32_t vi = 0;
 	for (GA_Iterator it(marker.vertexRange()); !it.atEnd(); ++it, ++vi) {
 		const auto nrmIdx = indices[vi];
-		const auto nrmPos = nrmIdx*3;
+		const auto nrmPos = nrmIdx * 3;
 		assert(nrmPos + 2 < nrmSize);
 		const auto nx = static_cast<fpreal32>(nrm[nrmPos + 0]);
 		const auto ny = static_cast<fpreal32>(nrm[nrmPos + 1]);
@@ -68,19 +65,13 @@ std::mutex mDetailMutex; // guard the houdini detail object
 
 } // namespace
 
-
 namespace ModelConversion {
 
-GA_Offset createPrimitives(GU_Detail* mDetail, GroupCreation gc, const wchar_t* name,
-                           const double* vtx, size_t vtxSize,
-                           const double* nrm, size_t nrmSize,
-                           const uint32_t* counts, size_t countsSize,
-                           const uint32_t* indices, size_t indicesSize,
-                           double const* const* uvs, size_t const* uvsSizes,
-                           uint32_t const* const* uvCounts, size_t const* uvCountsSizes,
-                           uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,
-                           uint32_t uvSets)
-{
+GA_Offset createPrimitives(GU_Detail* mDetail, GroupCreation gc, const wchar_t* name, const double* vtx, size_t vtxSize,
+                           const double* nrm, size_t nrmSize, const uint32_t* counts, size_t countsSize,
+                           const uint32_t* indices, size_t indicesSize, double const* const* uvs,
+                           size_t const* uvsSizes, uint32_t const* const* uvCounts, size_t const* uvCountsSizes,
+                           uint32_t const* const* uvIndices, size_t const* uvIndicesSizes, uint32_t uvSets) {
 	WA("all");
 
 	// -- create primitives
@@ -88,11 +79,12 @@ GA_Offset createPrimitives(GU_Detail* mDetail, GroupCreation gc, const wchar_t* 
 	const UTVector3FVector utPoints = convertVertices(vtx, vtxSize);
 	const GEO_PolyCounts geoPolyCounts = [&counts, &countsSize]() {
 		GEO_PolyCounts pc;
-		for (size_t ci = 0; ci < countsSize; ci++) pc.append(counts[ci]);
+		for (size_t ci = 0; ci < countsSize; ci++)
+			pc.append(counts[ci]);
 		return pc;
 	}();
-	const GA_Offset primStartOffset = GU_PrimPoly::buildBlock(mDetail, utPoints.data(), utPoints.size(),
-	                                                          geoPolyCounts, reinterpret_cast<const int*>(indices));
+	const GA_Offset primStartOffset = GU_PrimPoly::buildBlock(mDetail, utPoints.data(), utPoints.size(), geoPolyCounts,
+	                                                          reinterpret_cast<const int*>(indices));
 
 	// -- add vertex normals
 	if (nrmSize > 0) {
@@ -102,10 +94,12 @@ GA_Offset createPrimitives(GU_Detail* mDetail, GroupCreation gc, const wchar_t* 
 
 	// -- add texture coordinates
 	for (size_t uvSet = 0; uvSet < uvSets; uvSet++) {
-		size_t const psUVSSize       = uvsSizes[uvSet];
-		size_t const psUVCountsSize  = uvCountsSizes[uvSet];
+		size_t const psUVSSize = uvsSizes[uvSet];
+		size_t const psUVCountsSize = uvCountsSizes[uvSet];
 		size_t const psUVIndicesSize = uvIndicesSizes[uvSet];
-		if (DBG) LOG_DBG << "-- uvset " << uvSet << ": psUVCountsSize = " << psUVCountsSize << ", psUVIndicesSize = " << psUVIndicesSize;
+		if (DBG)
+			LOG_DBG << "-- uvset " << uvSet << ": psUVCountsSize = " << psUVCountsSize
+			        << ", psUVIndicesSize = " << psUVIndicesSize;
 
 		if (psUVSSize > 0 && psUVIndicesSize > 0 && psUVCountsSize > 0) {
 			GA_RWHandleV3 uvh;
@@ -116,19 +110,22 @@ GA_Offset createPrimitives(GU_Detail* mDetail, GroupCreation gc, const wchar_t* 
 				uvh.bind(mDetail->addTuple(GA_STORE_REAL32, GA_ATTRIB_VERTEX, GA_SCOPE_PUBLIC, n.c_str(), 3));
 			}
 
-			double const* const psUVS         = uvs[uvSet];
-			uint32_t const* const psUVCounts  = uvCounts[uvSet];
+			double const* const psUVS = uvs[uvSet];
+			uint32_t const* const psUVCounts = uvCounts[uvSet];
 			uint32_t const* const psUVIndices = uvIndices[uvSet];
 
 			size_t fi = 0;
 			size_t uvi = 0;
 			for (GA_Iterator pit(marker.primitiveRange()); !pit.atEnd(); ++pit, ++fi) {
 				GA_Primitive* prim = mDetail->getPrimitive(pit.getOffset());
-				if (DBG) LOG_DBG << "   fi = " << fi << ": prim vtx cnt = " << prim->getVertexCount() << ", vtx cnt = " << counts[fi] << ", uv cnt = " << psUVCounts[fi];
+				if (DBG)
+					LOG_DBG << "   fi = " << fi << ": prim vtx cnt = " << prim->getVertexCount()
+					        << ", vtx cnt = " << counts[fi] << ", uv cnt = " << psUVCounts[fi];
 
 				if (psUVCounts[fi] > 0) {
 					for (GA_Iterator vit(prim->getVertexRange()); !vit.atEnd(); ++vit, ++uvi) {
-						if (DBG) LOG_DBG << "      vi = " << *vit << ": uvi = " << uvi;
+						if (DBG)
+							LOG_DBG << "      vi = " << *vit << ": uvi = " << uvi;
 						assert(uvi < psUVIndicesSize);
 						const uint32_t uvIdx = psUVIndices[uvi];
 						const auto du = psUVS[uvIdx * 2 + 0];
@@ -155,46 +152,35 @@ GA_Offset createPrimitives(GU_Detail* mDetail, GroupCreation gc, const wchar_t* 
 
 } // namespace ModelConversion
 
+ModelConverter::ModelConverter(GU_Detail* detail, GroupCreation gc, std::vector<prt::Status>& statuses,
+                               UT_AutoInterrupt* autoInterrupt)
+    : mDetail(detail), mGroupCreation(gc), mStatuses(statuses), mAutoInterrupt(autoInterrupt) {}
 
-ModelConverter::ModelConverter(GU_Detail* detail, GroupCreation gc, std::vector<prt::Status>& statuses, UT_AutoInterrupt* autoInterrupt)
-: mDetail(detail), mGroupCreation(gc), mStatuses(statuses), mAutoInterrupt(autoInterrupt) { }
-
-void ModelConverter::add(
-		const wchar_t* name,
-		const double* vtx, size_t vtxSize,
-		const double* nrm, size_t nrmSize,
-		const uint32_t* counts, size_t countsSize,
-		const uint32_t* indices, size_t indicesSize,
-		double const* const* uvs, size_t const* uvsSizes,
-		uint32_t const* const* uvCounts, size_t const* uvCountsSizes,
-		uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,
-		uint32_t uvSets,
-		const uint32_t* faceRanges, size_t faceRangesSize,
-		const prt::AttributeMap** materials,
-		const prt::AttributeMap** reports,
-		const int32_t* shapeIDs)
-{
+void ModelConverter::add(const wchar_t* name, const double* vtx, size_t vtxSize, const double* nrm, size_t nrmSize,
+                         const uint32_t* counts, size_t countsSize, const uint32_t* indices, size_t indicesSize,
+                         double const* const* uvs, size_t const* uvsSizes, uint32_t const* const* uvCounts,
+                         size_t const* uvCountsSizes, uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,
+                         uint32_t uvSets, const uint32_t* faceRanges, size_t faceRangesSize,
+                         const prt::AttributeMap** materials, const prt::AttributeMap** reports,
+                         const int32_t* shapeIDs) {
 	// we need to protect mDetail, it is accessed by multiple generate threads
 	std::lock_guard<std::mutex> guard(mDetailMutex);
 
-	const GA_Offset primStartOffset = ModelConversion::createPrimitives(mDetail, mGroupCreation, name,
-	                                                                    vtx, vtxSize, nrm, nrmSize,
-	                                                                    counts, countsSize, indices, indicesSize,
-	                                                                    uvs, uvsSizes,
-	                                                                    uvCounts, uvCountsSizes,
-	                                                                    uvIndices, uvIndicesSizes,
-	                                                                    uvSets);
+	const GA_Offset primStartOffset = ModelConversion::createPrimitives(
+	        mDetail, mGroupCreation, name, vtx, vtxSize, nrm, nrmSize, counts, countsSize, indices, indicesSize, uvs,
+	        uvsSizes, uvCounts, uvCountsSizes, uvIndices, uvIndicesSizes, uvSets);
 
 	// -- convert materials/reports into primitive attributes based on face ranges
-	if (DBG) LOG_DBG << "got " << faceRangesSize-1 << " face ranges";
+	if (DBG)
+		LOG_DBG << "got " << faceRangesSize - 1 << " face ranges";
 	if (faceRangesSize > 1) {
 		WA("add materials/reports");
 
 		AttributeConversion::HandleMap handleMap;
 		const GA_IndexMap& primIndexMap = mDetail->getIndexMap(GA_ATTRIB_PRIMITIVE);
-		for (size_t fri = 0; fri < faceRangesSize-1; fri++) {
+		for (size_t fri = 0; fri < faceRangesSize - 1; fri++) {
 			const GA_Offset rangeStart = primStartOffset + faceRanges[fri];
-			const GA_Size   rangeSize  = faceRanges[fri + 1] - faceRanges[fri];
+			const GA_Size rangeSize = faceRanges[fri + 1] - faceRanges[fri];
 
 			if (materials != nullptr) {
 				const prt::AttributeMap* attrMap = materials[fri];
@@ -218,8 +204,8 @@ void ModelConverter::add(
 					const AttributeMapUPtr attrMap(it->second->createAttributeMap());
 					AttributeConversion::extractAttributeNames(handleMap, attrMap.get());
 					AttributeConversion::createAttributeHandles(mDetail, handleMap);
-					AttributeConversion::setAttributeValues(handleMap, attrMap.get(), primIndexMap,
-					                                        rangeStart, rangeSize);
+					AttributeConversion::setAttributeValues(handleMap, attrMap.get(), primIndexMap, rangeStart,
+					                                        rangeSize);
 				}
 			}
 		}
@@ -232,12 +218,14 @@ prt::Status ModelConverter::generateError(size_t isIndex, prt::Status status, co
 	return prt::STATUS_OK;
 }
 
-prt::Status ModelConverter::assetError(size_t isIndex, prt::CGAErrorLevel level, const wchar_t* key, const wchar_t* uri, const wchar_t* message) {
+prt::Status ModelConverter::assetError(size_t isIndex, prt::CGAErrorLevel level, const wchar_t* key, const wchar_t* uri,
+                                       const wchar_t* message) {
 	LOG_WRN << key << L": " << message;
 	return prt::STATUS_OK;
 }
 
-prt::Status ModelConverter::cgaError(size_t isIndex, int32_t shapeID, prt::CGAErrorLevel level, int32_t methodId, int32_t pc, const wchar_t* message) {
+prt::Status ModelConverter::cgaError(size_t isIndex, int32_t shapeID, prt::CGAErrorLevel level, int32_t methodId,
+                                     int32_t pc, const wchar_t* message) {
 	LOG_WRN << message;
 	return prt::STATUS_OK;
 }
@@ -271,19 +259,22 @@ AttributeMapBuilderUPtr& getBuilder(std::map<int32_t, AttributeMapBuilderUPtr>& 
 } // namespace
 
 prt::Status ModelConverter::attrBool(size_t isIndex, int32_t shapeID, const wchar_t* key, bool value) {
-	if (DBG) LOG_DBG << "attrBool: shapeID :" << shapeID << ", key: " << key << ", val: " << value;
+	if (DBG)
+		LOG_DBG << "attrBool: shapeID :" << shapeID << ", key: " << key << ", val: " << value;
 	getBuilder(mShapeAttributeBuilders, shapeID)->setBool(key, value);
 	return prt::STATUS_OK;
 }
 
 prt::Status ModelConverter::attrFloat(size_t isIndex, int32_t shapeID, const wchar_t* key, double value) {
-	if (DBG) LOG_DBG << "attrFloat: shapeID :" << shapeID << ", key: " << key << ", val: " << value;
+	if (DBG)
+		LOG_DBG << "attrFloat: shapeID :" << shapeID << ", key: " << key << ", val: " << value;
 	getBuilder(mShapeAttributeBuilders, shapeID)->setFloat(key, value);
 	return prt::STATUS_OK;
 }
 
 prt::Status ModelConverter::attrString(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* value) {
-	if (DBG) LOG_DBG << "attrString: shapeID :" << shapeID << ", key: " << key << ", val: " << value;
+	if (DBG)
+		LOG_DBG << "attrString: shapeID :" << shapeID << ", key: " << key << ", val: " << value;
 	getBuilder(mShapeAttributeBuilders, shapeID)->setString(key, value);
 	return prt::STATUS_OK;
 }

--- a/src/palladio/ModelConverter.h
+++ b/src/palladio/ModelConverter.h
@@ -82,17 +82,11 @@ protected:
 
 #if (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 1)
 	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr, size_t size,
-	                          size_t nRows) override {
-		return prt::STATUS_OK;
-	}
+	                          size_t nRows) override;
 	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr, size_t size,
-	                           size_t nRows) override {
-		return prt::STATUS_OK;
-	}
+	                           size_t nRows) override;
 	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr,
-	                            size_t size, size_t nRows) override {
-		return prt::STATUS_OK;
-	}
+	                            size_t size, size_t nRows) override;
 #elif (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 0)
 	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr,
 	                          size_t size) override {

--- a/src/palladio/ModelConverter.h
+++ b/src/palladio/ModelConverter.h
@@ -32,8 +32,8 @@
 #include "GEO/GEO_PolyCounts.h"
 #include "GU/GU_Detail.h"
 #include "GU/GU_PrimPoly.h"
-#include "UT/UT_Vector3.h"
 #include "UT/UT_Interrupt.h"
+#include "UT/UT_Vector3.h"
 
 #ifdef PLD_TC_GCC
 #	pragma GCC diagnostic pop
@@ -42,52 +42,36 @@
 #include <string>
 #include <vector>
 
-
 namespace ModelConversion {
 
-PLD_TEST_EXPORTS_API void getUVSet(
-	std::vector<uint32_t>& uvIndicesPerSet,
-	const uint32_t* counts, size_t countsSize,
-	const uint32_t* uvCounts, size_t uvCountsSize,
-	uint32_t uvSet, uint32_t uvSets,
-	const uint32_t* uvIndices, size_t uvIndicesSize
-);
+PLD_TEST_EXPORTS_API void getUVSet(std::vector<uint32_t>& uvIndicesPerSet, const uint32_t* counts, size_t countsSize,
+                                   const uint32_t* uvCounts, size_t uvCountsSize, uint32_t uvSet, uint32_t uvSets,
+                                   const uint32_t* uvIndices, size_t uvIndicesSize);
 
-void setUVs(
-	GA_RWHandleV3& handle, const GA_Detail::OffsetMarker& marker,
-	const uint32_t* counts, size_t countsSize,
-	const uint32_t* uvCounts, size_t uvCountsSize,
-	uint32_t uvSet, uint32_t uvSets,
-	const uint32_t* uvIndices, size_t uvIndicesSize,
-	const double* uvs, size_t uvsSize
-);
+void setUVs(GA_RWHandleV3& handle, const GA_Detail::OffsetMarker& marker, const uint32_t* counts, size_t countsSize,
+            const uint32_t* uvCounts, size_t uvCountsSize, uint32_t uvSet, uint32_t uvSets, const uint32_t* uvIndices,
+            size_t uvIndicesSize, const double* uvs, size_t uvsSize);
 
 } // namespace ModelConversion
 
 class ModelConverter : public HoudiniCallbacks {
 public:
-	explicit ModelConverter(GU_Detail* gdp, GroupCreation gc, std::vector<prt::Status>& statuses, UT_AutoInterrupt* autoInterrupt = nullptr);
+	explicit ModelConverter(GU_Detail* gdp, GroupCreation gc, std::vector<prt::Status>& statuses,
+	                        UT_AutoInterrupt* autoInterrupt = nullptr);
 
 protected:
-	void add(
-			const wchar_t* name,
-			const double* vtx, size_t vtxSize,
-			const double* nrm, size_t nrmSize,
-			const uint32_t* counts, size_t countsSize,
-			const uint32_t* indices, size_t indicesSize,
-			double const* const* uvs, size_t const* uvsSizes,
-			uint32_t const* const* uvCounts, size_t const* uvCountsSizes,
-			uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,
-			uint32_t uvSets,
-			const uint32_t* faceRanges, size_t faceRangesSize,
-			const prt::AttributeMap** materials,
-			const prt::AttributeMap** reports,
-			const int32_t* shapeIDs
-	) override;
+	void add(const wchar_t* name, const double* vtx, size_t vtxSize, const double* nrm, size_t nrmSize,
+	         const uint32_t* counts, size_t countsSize, const uint32_t* indices, size_t indicesSize,
+	         double const* const* uvs, size_t const* uvsSizes, uint32_t const* const* uvCounts,
+	         size_t const* uvCountsSizes, uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,
+	         uint32_t uvSets, const uint32_t* faceRanges, size_t faceRangesSize, const prt::AttributeMap** materials,
+	         const prt::AttributeMap** reports, const int32_t* shapeIDs) override;
 
 	prt::Status generateError(size_t isIndex, prt::Status status, const wchar_t* message) override;
-	prt::Status assetError(size_t isIndex, prt::CGAErrorLevel level, const wchar_t* key, const wchar_t* uri, const wchar_t* message) override;
-	prt::Status cgaError(size_t isIndex, int32_t shapeID, prt::CGAErrorLevel level, int32_t methodId, int32_t pc, const wchar_t* message) override;
+	prt::Status assetError(size_t isIndex, prt::CGAErrorLevel level, const wchar_t* key, const wchar_t* uri,
+	                       const wchar_t* message) override;
+	prt::Status cgaError(size_t isIndex, int32_t shapeID, prt::CGAErrorLevel level, int32_t methodId, int32_t pc,
+	                     const wchar_t* message) override;
 	prt::Status cgaPrint(size_t isIndex, int32_t shapeID, const wchar_t* txt) override;
 	prt::Status cgaReportBool(size_t isIndex, int32_t shapeID, const wchar_t* key, bool value) override;
 	prt::Status cgaReportFloat(size_t isIndex, int32_t shapeID, const wchar_t* key, double value) override;
@@ -97,13 +81,31 @@ protected:
 	prt::Status attrString(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* value) override;
 
 #if (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 1)
-	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr, size_t size, size_t nRows) override { return prt::STATUS_OK; }
-	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr, size_t size, size_t nRows) override { return prt::STATUS_OK; }
-	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr, size_t size, size_t nRows) override { return prt::STATUS_OK; }
+	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr, size_t size,
+	                          size_t nRows) override {
+		return prt::STATUS_OK;
+	}
+	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr, size_t size,
+	                           size_t nRows) override {
+		return prt::STATUS_OK;
+	}
+	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr,
+	                            size_t size, size_t nRows) override {
+		return prt::STATUS_OK;
+	}
 #elif (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 0)
-	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr, size_t size) override { return prt::STATUS_OK; }
-	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr, size_t size) override { return prt::STATUS_OK; }
-	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr, size_t size) override { return prt::STATUS_OK; }
+	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr,
+	                          size_t size) override {
+		return prt::STATUS_OK;
+	}
+	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr,
+	                           size_t size) override {
+		return prt::STATUS_OK;
+	}
+	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr,
+	                            size_t size) override {
+		return prt::STATUS_OK;
+	}
 #endif
 
 	prt::Callbacks::Continuation progress(float percentageCompleted) override {
@@ -114,7 +116,7 @@ protected:
 
 private:
 	GU_Detail* mDetail;
-    GroupCreation mGroupCreation;
+	GroupCreation mGroupCreation;
 	std::vector<prt::Status>& mStatuses;
 	UT_AutoInterrupt* mAutoInterrupt;
 	std::map<int32_t, AttributeMapBuilderUPtr> mShapeAttributeBuilders;

--- a/src/palladio/ModelConverter.h
+++ b/src/palladio/ModelConverter.h
@@ -96,7 +96,11 @@ protected:
 	prt::Status attrFloat(size_t isIndex, int32_t shapeID, const wchar_t* key, double value) override;
 	prt::Status attrString(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* value) override;
 
-#if (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 0)
+#if (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 1)
+	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr, size_t size, size_t nRows) override { return prt::STATUS_OK; }
+	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr, size_t size, size_t nRows) override { return prt::STATUS_OK; }
+	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr, size_t size, size_t nRows) override { return prt::STATUS_OK; }
+#elif (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 0)
 	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr, size_t size) override { return prt::STATUS_OK; }
 	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr, size_t size) override { return prt::STATUS_OK; }
 	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr, size_t size) override { return prt::STATUS_OK; }

--- a/src/palladio/MultiWatch.cpp
+++ b/src/palladio/MultiWatch.cpp
@@ -17,12 +17,11 @@
 #include "MultiWatch.h"
 #include "LogHandler.h"
 
-#include <mutex>
-#include <iomanip>
 #include <algorithm>
-#include <numeric>
 #include <cmath>
-
+#include <iomanip>
+#include <mutex>
+#include <numeric>
 
 namespace {
 
@@ -65,14 +64,14 @@ void MultiWatch::stop(const std::string& name) {
 
 void MultiWatch::printTimings() const {
 	std::map<std::string, std::vector<double>> lapTimes;
-	for (const auto& l: laps) {
-		for (const auto& ctx: l) {
+	for (const auto& l : laps) {
+		for (const auto& ctx : l) {
 			lapTimes[ctx.first].push_back(ctx.second);
 		}
 	}
 
 	LOG_FTL << "-- timings:";
-	for (const auto& l: lapTimes) {
+	for (const auto& l : lapTimes) {
 		const auto& ctxName = l.first;
 		const auto& lt = l.second;
 
@@ -80,9 +79,9 @@ void MultiWatch::printTimings() const {
 		const double lapSum = std::accumulate(lt.begin(), lt.end(), 0.0);
 		const double lapAvg = lapSum / (double)numLaps;
 		const auto avgIntStrWidth = std::to_string(std::trunc(lapAvg)).size();
-		LOG_FTL << "   " << ctxName
-		        << std::setw(75 - ctxName.size()) << std::right << std::fixed << std::setprecision(5-avgIntStrWidth) << lapAvg << "s"
-		        << std::setw(15) << std::right << "(#laps = " << numLaps << ")";
+		LOG_FTL << "   " << ctxName << std::setw(75 - ctxName.size()) << std::right << std::fixed
+		        << std::setprecision(5 - avgIntStrWidth) << lapAvg << "s" << std::setw(15) << std::right
+		        << "(#laps = " << numLaps << ")";
 	}
 }
 
@@ -97,5 +96,5 @@ WatchAgent::~WatchAgent() {
 std::string WatchAgent::stripArgs(const std::string& s) {
 	std::string t = s.substr(0, s.find_first_of('('));
 	auto p = t.find_last_of(' ');
-	return (p != std::string::npos) ? t.substr(p+1) : t;
+	return (p != std::string::npos) ? t.substr(p + 1) : t;
 }

--- a/src/palladio/MultiWatch.h
+++ b/src/palladio/MultiWatch.h
@@ -16,16 +16,14 @@
 
 #pragma once
 
-#include <string>
-#include <map>
 #include <chrono>
+#include <map>
+#include <string>
 #include <vector>
 
-
-#define WA(x) //WatchAgent wa_(x, __PRETTY_FUNCTION__)
-#define WA_NEW_LAP //theWatch.newLap();
-#define WA_PRINT_TIMINGS //theWatch.printTimings();
-
+#define WA(x)            // WatchAgent wa_(x, __PRETTY_FUNCTION__)
+#define WA_NEW_LAP       // theWatch.newLap();
+#define WA_PRINT_TIMINGS // theWatch.printTimings();
 
 class MultiWatch {
 public:
@@ -42,7 +40,6 @@ public:
 };
 
 extern MultiWatch theWatch;
-
 
 class WatchAgent {
 public:

--- a/src/palladio/NodeParameter.h
+++ b/src/palladio/NodeParameter.h
@@ -16,17 +16,17 @@
 
 #pragma once
 
-#include "ShapeConverter.h"
 #include "PrimitiveClassifier.h"
+#include "ShapeConverter.h"
 #include "Utils.h"
 
-#include "PRM/PRM_ChoiceList.h"
-#include "PRM/PRM_Parm.h"
-#include "PRM/PRM_SpareData.h"
-#include "PRM/PRM_Shared.h"
-#include "PRM/PRM_Callback.h"
 #include "GA/GA_Types.h"
 #include "OP/OP_Node.h"
+#include "PRM/PRM_Callback.h"
+#include "PRM/PRM_ChoiceList.h"
+#include "PRM/PRM_Parm.h"
+#include "PRM/PRM_Shared.h"
+#include "PRM/PRM_SpareData.h"
 
 // clang-format off
 #include "BoostRedirect.h"
@@ -37,7 +37,8 @@ namespace AssignNodeParams {
 
 // -- PRIMITIVE CLASSIFIER NAME
 static PRM_Name PRIM_CLS("primClsAttr", "Primitive Classifier");
-const std::string PRIM_CLS_HELP = "Classifies primitives into input shapes and sets value for primitive attribute '" + PLD_PRIM_CLS_NAME.toStdString() + "'";
+const std::string PRIM_CLS_HELP = "Classifies primitives into input shapes and sets value for primitive attribute '" +
+                                  PLD_PRIM_CLS_NAME.toStdString() + "'";
 static PRM_Default PRIM_CLS_DEFAULT(0.0f, "primCls", CH_STRING_LITERAL);
 
 const auto getPrimClsName = [](const OP_Node* node, fpreal t) -> UT_String {
@@ -49,7 +50,6 @@ const auto getPrimClsName = [](const OP_Node* node, fpreal t) -> UT_String {
 const auto setPrimClsName = [](OP_Node* node, const UT_String& name, fpreal t) {
 	node->setString(name, CH_STRING_LITERAL, PRIM_CLS.getToken(), 0, t);
 };
-
 
 // -- RULE PACKAGE
 static PRM_Name RPK("rpk", "Rule Package");
@@ -65,16 +65,14 @@ const auto getRPK = [](const OP_Node* node, fpreal t) -> PLD_BOOST_NS::filesyste
 	return s.toStdString();
 };
 
-
 // -- RPK RELOADER
 static PRM_Name RPK_RELOAD("rpkReload", "Reload Rule Package");
-
 
 // -- RULE FILE (cgb)
 static PRM_Name RULE_FILE("ruleFile", "Rule File");
 const std::string RULE_FILE_HELP = "Sets value for primitive attribute '" + PLD_RULE_FILE.toStdString() + "'";
 
-void buildRuleFileMenu(void *data, PRM_Name *theMenu, int theMaxSize, const PRM_SpareData *, const PRM_Parm *);
+void buildRuleFileMenu(void* data, PRM_Name* theMenu, int theMaxSize, const PRM_SpareData*, const PRM_Parm*);
 
 static PRM_ChoiceList ruleFileMenu(static_cast<PRM_ChoiceListType>(PRM_CHOICELIST_REPLACE), &buildRuleFileMenu);
 
@@ -89,12 +87,11 @@ const auto setRuleFile = [](OP_Node* node, const std::wstring& ruleFile, fpreal 
 	node->setString(val, CH_STRING_LITERAL, RULE_FILE.getToken(), 0, t);
 };
 
-
 // -- STYLE
 static PRM_Name STYLE("style", "Style");
 const std::string STYLE_HELP = "Sets value for primitive attribute '" + PLD_STYLE.toStdString() + "'";
 
-void buildStyleMenu(void *data, PRM_Name *theMenu, int theMaxSize, const PRM_SpareData *, const PRM_Parm *);
+void buildStyleMenu(void* data, PRM_Name* theMenu, int theMaxSize, const PRM_SpareData*, const PRM_Parm*);
 
 static PRM_ChoiceList styleMenu(static_cast<PRM_ChoiceListType>(PRM_CHOICELIST_REPLACE), &buildStyleMenu);
 
@@ -109,12 +106,11 @@ const auto setStyle = [](OP_Node* node, const std::wstring& s, fpreal t) {
 	node->setString(val, CH_STRING_LITERAL, STYLE.getToken(), 0, t);
 };
 
-
 // -- START RULE
 static PRM_Name START_RULE("startRule", "Start Rule");
 const std::string START_RULE_HELP = "Sets value for primitive attribute '" + PLD_START_RULE.toStdString() + "'";
 
-void buildStartRuleMenu(void *data, PRM_Name *theMenu, int theMaxSize, const PRM_SpareData *, const PRM_Parm *);
+void buildStartRuleMenu(void* data, PRM_Name* theMenu, int theMaxSize, const PRM_SpareData*, const PRM_Parm*);
 
 static PRM_ChoiceList startRuleMenu(static_cast<PRM_ChoiceListType>(PRM_CHOICELIST_REPLACE), &buildStartRuleMenu);
 
@@ -129,56 +125,55 @@ const auto setStartRule = [](OP_Node* node, const std::wstring& s, fpreal t) {
 	node->setString(val, CH_STRING_LITERAL, START_RULE.getToken(), 0, t);
 };
 
-
 // -- ASSIGN NODE PARAMS
 static PRM_Template PARAM_TEMPLATES[] = {
-		PRM_Template(PRM_STRING,   1, &PRIM_CLS,   &PRIM_CLS_DEFAULT, nullptr,        nullptr, PRM_Callback(), nullptr,                             1, PRIM_CLS_HELP.c_str()),
-		PRM_Template(PRM_FILE,     1, &RPK,        &RPK_DEFAULT,      nullptr,        nullptr, rpkCallback,    &PRM_SpareData::fileChooserModeRead, 1, RPK_HELP.c_str()),
-		PRM_Template(PRM_CALLBACK, 1, &RPK_RELOAD, PRMoneDefaults,    nullptr,        nullptr, rpkCallback),
-		PRM_Template(PRM_STRING,   1, &RULE_FILE,  PRMoneDefaults,    &ruleFileMenu,  nullptr, PRM_Callback(), nullptr,                             1, RULE_FILE_HELP.c_str()),
-		PRM_Template(PRM_STRING,   1, &STYLE,      PRMoneDefaults,    &styleMenu,     nullptr, PRM_Callback(), nullptr,                             1, STYLE_HELP.c_str()),
-		PRM_Template(PRM_STRING,   1, &START_RULE, PRMoneDefaults,    &startRuleMenu, nullptr, PRM_Callback(), nullptr,                             1, START_RULE_HELP.c_str()),
-		PRM_Template()
-};
+        PRM_Template(PRM_STRING, 1, &PRIM_CLS, &PRIM_CLS_DEFAULT, nullptr, nullptr, PRM_Callback(), nullptr, 1,
+                     PRIM_CLS_HELP.c_str()),
+        PRM_Template(PRM_FILE, 1, &RPK, &RPK_DEFAULT, nullptr, nullptr, rpkCallback,
+                     &PRM_SpareData::fileChooserModeRead, 1, RPK_HELP.c_str()),
+        PRM_Template(PRM_CALLBACK, 1, &RPK_RELOAD, PRMoneDefaults, nullptr, nullptr, rpkCallback),
+        PRM_Template(PRM_STRING, 1, &RULE_FILE, PRMoneDefaults, &ruleFileMenu, nullptr, PRM_Callback(), nullptr, 1,
+                     RULE_FILE_HELP.c_str()),
+        PRM_Template(PRM_STRING, 1, &STYLE, PRMoneDefaults, &styleMenu, nullptr, PRM_Callback(), nullptr, 1,
+                     STYLE_HELP.c_str()),
+        PRM_Template(PRM_STRING, 1, &START_RULE, PRMoneDefaults, &startRuleMenu, nullptr, PRM_Callback(), nullptr, 1,
+                     START_RULE_HELP.c_str()),
+        PRM_Template()};
 
 } // namespace AssignNodeParams
-
 
 namespace GenerateNodeParams {
 
 static PRM_Name GROUP_CREATION("groupCreation", "Primitive Groups");
-static const char* GROUP_CREATION_TOKENS[] = { "NONE", "PRIMCLS" };
-static const char* GROUP_CREATION_LABELS[] = {
-	"Do not create groups",
-	"One group per primitive classifier"
-};
-static PRM_Name GROUP_CREATION_MENU_ITEMS[] = {
-	PRM_Name(GROUP_CREATION_TOKENS[0], GROUP_CREATION_LABELS[0]),
-	PRM_Name(GROUP_CREATION_TOKENS[1], GROUP_CREATION_LABELS[1]),
-	PRM_Name(nullptr)
-};
-static PRM_ChoiceList groupCreationMenu((PRM_ChoiceListType)(PRM_CHOICELIST_EXCLUSIVE | PRM_CHOICELIST_REPLACE), GROUP_CREATION_MENU_ITEMS);
+static const char* GROUP_CREATION_TOKENS[] = {"NONE", "PRIMCLS"};
+static const char* GROUP_CREATION_LABELS[] = {"Do not create groups", "One group per primitive classifier"};
+static PRM_Name GROUP_CREATION_MENU_ITEMS[] = {PRM_Name(GROUP_CREATION_TOKENS[0], GROUP_CREATION_LABELS[0]),
+                                               PRM_Name(GROUP_CREATION_TOKENS[1], GROUP_CREATION_LABELS[1]),
+                                               PRM_Name(nullptr)};
+static PRM_ChoiceList groupCreationMenu((PRM_ChoiceListType)(PRM_CHOICELIST_EXCLUSIVE | PRM_CHOICELIST_REPLACE),
+                                        GROUP_CREATION_MENU_ITEMS);
 const size_t DEFAULT_GROUP_CREATION_ORDINAL = 0;
 static PRM_Default DEFAULT_GROUP_CREATION(0, GROUP_CREATION_TOKENS[DEFAULT_GROUP_CREATION_ORDINAL]);
 
 const auto getGroupCreation = [](const OP_Node* node, fpreal t) -> GroupCreation {
 	const auto ord = node->evalInt(GROUP_CREATION.getToken(), 0, t);
 	switch (ord) {
-		case 0: return GroupCreation::NONE;
-		case 1: return GroupCreation::PRIMCLS;
-		default: return GroupCreation::NONE;
+		case 0:
+			return GroupCreation::NONE;
+		case 1:
+			return GroupCreation::PRIMCLS;
+		default:
+			return GroupCreation::NONE;
 	}
 };
 
 static PRM_Name EMIT_ATTRS("emitAttrs", "Re-emit set CGA attributes");
 static PRM_Name EMIT_MATERIAL("emitMaterials", "Emit material attributes");
 static PRM_Name EMIT_REPORTS("emitReports", "Emit CGA reports");
-static PRM_Template PARAM_TEMPLATES[] {
-		PRM_Template(PRM_ORD, PRM_Template::PRM_EXPORT_MAX, 1, &GROUP_CREATION, &DEFAULT_GROUP_CREATION, &groupCreationMenu),
-		PRM_Template(PRM_TOGGLE, 1, &EMIT_ATTRS),
-		PRM_Template(PRM_TOGGLE, 1, &EMIT_MATERIAL),
-		PRM_Template(PRM_TOGGLE, 1, &EMIT_REPORTS),
-		PRM_Template()
-};
+static PRM_Template PARAM_TEMPLATES[]{PRM_Template(PRM_ORD, PRM_Template::PRM_EXPORT_MAX, 1, &GROUP_CREATION,
+                                                   &DEFAULT_GROUP_CREATION, &groupCreationMenu),
+                                      PRM_Template(PRM_TOGGLE, 1, &EMIT_ATTRS),
+                                      PRM_Template(PRM_TOGGLE, 1, &EMIT_MATERIAL),
+                                      PRM_Template(PRM_TOGGLE, 1, &EMIT_REPORTS), PRM_Template()};
 
 } // namespace GenerateNodeParams

--- a/src/palladio/NodeParameter.h
+++ b/src/palladio/NodeParameter.h
@@ -28,9 +28,10 @@
 #include "GA/GA_Types.h"
 #include "OP/OP_Node.h"
 
+// clang-format off
 #include "BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/filesystem/path.hpp)
-
+// clang-format on
 
 namespace AssignNodeParams {
 

--- a/src/palladio/PRTContext.cpp
+++ b/src/palladio/PRTContext.cpp
@@ -15,42 +15,41 @@
  */
 
 #include "PRTContext.h"
-#include "PalladioMain.h"
 #include "LogHandler.h"
+#include "PalladioMain.h"
 #include "SOPAssign.h"
 
 #if PRT_VERSION_MAJOR < 2
 #	include "prt/FlexLicParams.h"
 #endif
 
-#include "OP/OP_Node.h"
 #include "OP/OP_Director.h"
 #include "OP/OP_Network.h"
+#include "OP/OP_Node.h"
 
-#include <thread>
 #include <mutex>
-
+#include <thread>
 
 namespace {
 
-constexpr const wchar_t*      PLD_LOG_PREFIX          = L"pld";
-constexpr const char*         PLD_TMP_PREFIX          = "palladio_";
+constexpr const wchar_t* PLD_LOG_PREFIX = L"pld";
+constexpr const char* PLD_TMP_PREFIX = "palladio_";
 
-constexpr const char*         PRT_LIB_SUBDIR          = "prtlib";
+constexpr const char* PRT_LIB_SUBDIR = "prtlib";
 
-constexpr const prt::LogLevel PRT_LOG_LEVEL_DEFAULT   = prt::LOG_ERROR;
-constexpr const char*         PRT_LOG_LEVEL_ENV_VAR   = "CITYENGINE_LOG_LEVEL";
-constexpr const char*         PRT_LOG_LEVEL_STRINGS[] = { "trace", "debug", "info", "warning", "error", "fatal" };
-constexpr const size_t        PRT_LOG_LEVEL_STRINGS_N = sizeof(PRT_LOG_LEVEL_STRINGS)/sizeof(PRT_LOG_LEVEL_STRINGS[0]);
+constexpr const prt::LogLevel PRT_LOG_LEVEL_DEFAULT = prt::LOG_ERROR;
+constexpr const char* PRT_LOG_LEVEL_ENV_VAR = "CITYENGINE_LOG_LEVEL";
+constexpr const char* PRT_LOG_LEVEL_STRINGS[] = {"trace", "debug", "info", "warning", "error", "fatal"};
+constexpr const size_t PRT_LOG_LEVEL_STRINGS_N = sizeof(PRT_LOG_LEVEL_STRINGS) / sizeof(PRT_LOG_LEVEL_STRINGS[0]);
 
 #if PRT_VERSION_MAJOR < 2
 
-constexpr const char*         FILE_FLEXNET_LIB        = "flexnet_prt";
-constexpr const char*         PRT_LIC_ENV_VAR         = "CITYENGINE_LICENSE_SERVER";
+constexpr const char* FILE_FLEXNET_LIB = "flexnet_prt";
+constexpr const char* PRT_LIC_ENV_VAR = "CITYENGINE_LICENSE_SERVER";
 
 class License {
 private:
-    prt::FlexLicParams flexLicParams;
+	prt::FlexLicParams flexLicParams;
 
 	std::string libflexnetPath; // owns flexLicParams.mActLibPath char ptr
 	std::string licFeature;     // owns flexLicParams.mFeature
@@ -58,7 +57,7 @@ private:
 
 public:
 	License(const PLD_BOOST_NS::filesystem::path& prtRootPath) {
-        const std::string libflexnet = getSharedLibraryPrefix() + FILE_FLEXNET_LIB + getSharedLibrarySuffix();
+		const std::string libflexnet = getSharedLibraryPrefix() + FILE_FLEXNET_LIB + getSharedLibrarySuffix();
 
 		libflexnetPath = (prtRootPath / libflexnet).string();
 		flexLicParams.mActLibPath = libflexnetPath.c_str();
@@ -72,7 +71,7 @@ public:
 		}
 
 		flexLicParams.mFeature = licFeature.c_str();
-        flexLicParams.mHostName = licServer.c_str();
+		flexLicParams.mHostName = licServer.c_str();
 
 		LOG_INF << "CityEngine license: feature = '" << licFeature << "', server = '" << licServer << "'";
 	}
@@ -95,10 +94,10 @@ prt::LogLevel getLogLevel() {
 	return PRT_LOG_LEVEL_DEFAULT;
 }
 
-template<typename C>
+template <typename C>
 std::vector<const C*> toPtrVec(const std::vector<std::basic_string<C>>& sv) {
 	std::vector<const C*> pv(sv.size());
-	std::transform(sv.begin(), sv.end(), pv.begin(), [](const std::basic_string<C>& s){ return s.c_str(); });
+	std::transform(sv.begin(), sv.end(), pv.begin(), [](const std::basic_string<C>& s) { return s.c_str(); });
 	return pv;
 }
 
@@ -116,17 +115,18 @@ void scheduleRecook(const PLD_BOOST_NS::filesystem::path& rpk) {
 			auto visitedRPK = reinterpret_cast<PLD_BOOST_NS::filesystem::path*>(data);
 			SOPAssign& sa = static_cast<SOPAssign&>(n);
 			if (sa.getRPK() == *visitedRPK) {
-				LOG_DBG << "forcing recook of: " << n.getName() << ", " << n.getOpType() << ", " << n.getOperator()->getName();
+				LOG_DBG << "forcing recook of: " << n.getName() << ", " << n.getOpType() << ", "
+				        << n.getOperator()->getName();
 				sa.forceRecook();
 			}
 		}
 		return false;
 	};
 
-    if (OPgetDirector() != nullptr) {
-	    OP_Network* objMgr = OPgetDirector()->getManager("obj");
-	    objMgr->traverseChildren(visit, const_cast<void*>(reinterpret_cast<const void*>(&rpk)), true);
-    }
+	if (OPgetDirector() != nullptr) {
+		OP_Network* objMgr = OPgetDirector()->getManager("obj");
+		objMgr->traverseChildren(visit, const_cast<void*>(reinterpret_cast<const void*>(&rpk)), true);
+	}
 }
 
 PLD_BOOST_NS::filesystem::path getProcessTempDir() {
@@ -135,30 +135,25 @@ PLD_BOOST_NS::filesystem::path getProcessTempDir() {
 	if (!ec)
 		tp = "/tmp/"; // TODO: other OSes
 	std::string n = std::string(PLD_TMP_PREFIX) + std::to_string(::getpid());
-	return { "/tmp/" + n };
+	return {"/tmp/" + n};
 }
 
 } // namespace
 
-
 PRTContext::PRTContext(const std::vector<PLD_BOOST_NS::filesystem::path>& addExtDirs)
-        : mLogHandler(new logging::LogHandler(PLD_LOG_PREFIX)),
-          mPRTHandle{nullptr},
-          mPRTCache{prt::CacheObject::create(prt::CacheObject::CACHE_TYPE_DEFAULT)},
-          mCores{getNumCores()},
-          mResolveMapCache{new ResolveMapCache(getProcessTempDir())}
-{
-    const prt::LogLevel logLevel = getLogLevel();
+    : mLogHandler(new logging::LogHandler(PLD_LOG_PREFIX)), mPRTHandle{nullptr},
+      mPRTCache{prt::CacheObject::create(prt::CacheObject::CACHE_TYPE_DEFAULT)}, mCores{getNumCores()},
+      mResolveMapCache{new ResolveMapCache(getProcessTempDir())} {
+	const prt::LogLevel logLevel = getLogLevel();
 	prt::setLogLevel(logLevel);
 	prt::addLogHandler(mLogHandler.get());
 
 	// -- get the dir containing prt core library
-	const auto rootPath = [](){
-        PLD_BOOST_NS::filesystem::path prtCorePath;
+	const auto rootPath = []() {
+		PLD_BOOST_NS::filesystem::path prtCorePath;
 		getLibraryPath(prtCorePath, reinterpret_cast<const void*>(prt::init));
 		return prtCorePath.parent_path();
 	}();
-
 
 #if PRT_VERSION_MAJOR < 2
 	// -- detect license
@@ -166,10 +161,10 @@ PRTContext::PRTContext(const std::vector<PLD_BOOST_NS::filesystem::path>& addExt
 #endif
 
 	// -- scan for directories with prt extensions
-	const std::vector<PLD_BOOST_NS::filesystem::path> extDirs = [&rootPath,&addExtDirs](){
+	const std::vector<PLD_BOOST_NS::filesystem::path> extDirs = [&rootPath, &addExtDirs]() {
 		std::vector<PLD_BOOST_NS::filesystem::path> ed;
 		ed.emplace_back(rootPath / PRT_LIB_SUBDIR);
-		for (auto d: addExtDirs) { // get a copy
+		for (auto d : addExtDirs) { // get a copy
 			if (PLD_BOOST_NS::filesystem::is_regular_file(d))
 				d = d.parent_path();
 			if (!d.is_absolute())
@@ -180,26 +175,26 @@ PRTContext::PRTContext(const std::vector<PLD_BOOST_NS::filesystem::path>& addExt
 	}();
 	const std::vector<std::wstring> extDirStrs = [&extDirs]() {
 		std::vector<std::wstring> sv;
-		for (const auto& d: extDirs)
+		for (const auto& d : extDirs)
 			sv.emplace_back(d.wstring());
 		return sv;
 	}();
 	const auto extDirCStrs = toPtrVec(extDirStrs); // depends on extDirStrs life-time!
 
 	// -- initialize PRT
-    prt::Status status = prt::STATUS_UNSPECIFIED_ERROR;
-    mPRTHandle.reset(prt::init(extDirCStrs.data(), extDirCStrs.size(), logLevel,
+	prt::Status status = prt::STATUS_UNSPECIFIED_ERROR;
+	mPRTHandle.reset(prt::init(extDirCStrs.data(), extDirCStrs.size(), logLevel,
 #if PRT_VERSION_MAJOR < 2
-    		license.getParams(),
+	                           license.getParams(),
 #endif
-    		&status));
-    if (status != prt::STATUS_OK) {
-        LOG_FTL << "Could not initialize PRT: " << prt::getStatusDescription(status);
-    }
+	                           &status));
+	if (status != prt::STATUS_OK) {
+		LOG_FTL << "Could not initialize PRT: " << prt::getStatusDescription(status);
+	}
 }
 
 PRTContext::~PRTContext() {
-    mResolveMapCache.reset();
+	mResolveMapCache.reset();
 	LOG_INF << "Released RPK Cache";
 
 	mPRTCache.reset(); // calling reset manually to ensure order
@@ -208,11 +203,11 @@ PRTContext::~PRTContext() {
 	mPRTHandle.reset(); // same here
 	LOG_INF << "Shutdown PRT & returned license";
 
-    prt::removeLogHandler(mLogHandler.get());
+	prt::removeLogHandler(mLogHandler.get());
 }
 
 namespace {
-	std::mutex mResolveMapCacheMutex;
+std::mutex mResolveMapCacheMutex;
 }
 
 ResolveMapSPtr PRTContext::getResolveMap(const PLD_BOOST_NS::filesystem::path& rpk) {

--- a/src/palladio/PRTContext.h
+++ b/src/palladio/PRTContext.h
@@ -22,8 +22,10 @@
 
 #include "prt/Object.h"
 
+// clang-format off
 #include "BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/filesystem.hpp)
+// clang-format on
 
 #include <map>
 

--- a/src/palladio/PRTContext.h
+++ b/src/palladio/PRTContext.h
@@ -29,11 +29,10 @@
 
 #include <map>
 
-
 namespace logging {
 class LogHandler;
 using LogHandlerPtr = std::unique_ptr<LogHandler>;
-}
+} // namespace logging
 
 /**
  * manage PRT "lifetime" (actually, its license lifetime)
@@ -47,13 +46,15 @@ struct PLD_TEST_EXPORTS_API PRTContext final {
 	~PRTContext();
 
 	ResolveMapSPtr getResolveMap(const PLD_BOOST_NS::filesystem::path& rpk);
-	bool isAlive() const { return mPRTHandle.operator bool(); }
+	bool isAlive() const {
+		return mPRTHandle.operator bool();
+	}
 
-	logging::LogHandlerPtr  mLogHandler;
-	ObjectUPtr              mPRTHandle;
-	CacheObjectUPtr         mPRTCache;
-	const uint32_t          mCores;
-	ResolveMapCacheUPtr     mResolveMapCache;
+	logging::LogHandlerPtr mLogHandler;
+	ObjectUPtr mPRTHandle;
+	CacheObjectUPtr mPRTCache;
+	const uint32_t mCores;
+	ResolveMapCacheUPtr mResolveMapCache;
 };
 
 using PRTContextUPtr = std::unique_ptr<PRTContext>;

--- a/src/palladio/PalladioMain.cpp
+++ b/src/palladio/PalladioMain.cpp
@@ -16,10 +16,10 @@
 
 #include "PalladioMain.h"
 
+#include "NodeParameter.h"
 #include "PRTContext.h"
 #include "SOPAssign.h"
 #include "SOPGenerate.h"
-#include "NodeParameter.h"
 
 #include "OP/OP_OperatorTable.h"
 #include "UT/UT_Exit.h"
@@ -28,7 +28,6 @@
 //#undef minor
 #include "UT/UT_DSOVersion.h"
 
-
 namespace {
 
 // prt lifecycle
@@ -36,29 +35,26 @@ PRTContextUPtr prtCtx;
 
 } // namespace
 
-
-void newSopOperator(OP_OperatorTable *table) {
+void newSopOperator(OP_OperatorTable* table) {
 	if (!prtCtx) {
 		prtCtx.reset(new PRTContext());
-		UT_Exit::addExitCallback([](void *) { prtCtx.reset(); });
+		UT_Exit::addExitCallback([](void*) { prtCtx.reset(); });
 	}
 
 	if (!prtCtx->isAlive())
 		return;
 
 	// instantiate assign sop
-	auto createSOPAssign = [](OP_Network *net, const char *name, OP_Operator *op) -> OP_Node* {
+	auto createSOPAssign = [](OP_Network* net, const char* name, OP_Operator* op) -> OP_Node* {
 		return new SOPAssign(prtCtx, net, name, op);
 	};
-	table->addOperator(new OP_Operator(OP_PLD_ASSIGN, OP_PLD_ASSIGN, createSOPAssign,
-			AssignNodeParams::PARAM_TEMPLATES, 1, 1, nullptr, OP_FLAG_GENERATOR
-	));
+	table->addOperator(new OP_Operator(OP_PLD_ASSIGN, OP_PLD_ASSIGN, createSOPAssign, AssignNodeParams::PARAM_TEMPLATES,
+	                                   1, 1, nullptr, OP_FLAG_GENERATOR));
 
 	// instantiate generator sop
-	auto createSOPGenerate = [](OP_Network *net, const char *name, OP_Operator *op) -> OP_Node* {
+	auto createSOPGenerate = [](OP_Network* net, const char* name, OP_Operator* op) -> OP_Node* {
 		return new SOPGenerate(prtCtx, net, name, op);
 	};
 	table->addOperator(new OP_Operator(OP_PLD_GENERATE, OP_PLD_GENERATE, createSOPGenerate,
-	       GenerateNodeParams::PARAM_TEMPLATES, 1, 1, nullptr, OP_FLAG_GENERATOR
-	));
+	                                   GenerateNodeParams::PARAM_TEMPLATES, 1, 1, nullptr, OP_FLAG_GENERATOR));
 }

--- a/src/palladio/PalladioMain.cpp
+++ b/src/palladio/PalladioMain.cpp
@@ -20,6 +20,7 @@
 #include "PRTContext.h"
 #include "SOPAssign.h"
 #include "SOPGenerate.h"
+#include "LogHandler.h"
 
 #include "OP/OP_OperatorTable.h"
 #include "UT/UT_Exit.h"
@@ -57,4 +58,6 @@ void newSopOperator(OP_OperatorTable* table) {
 	};
 	table->addOperator(new OP_Operator(OP_PLD_GENERATE, OP_PLD_GENERATE, createSOPGenerate,
 	                                   GenerateNodeParams::PARAM_TEMPLATES, 1, 1, nullptr, OP_FLAG_GENERATOR));
+
+	LOG_INF << "Palladio " << PLD_VERSION << " initialized.";
 }

--- a/src/palladio/PalladioMain.h
+++ b/src/palladio/PalladioMain.h
@@ -23,8 +23,8 @@
 #		define PLD_TEST_EXPORTS_API
 #	endif
 #else
-#	define PLD_TEST_EXPORTS_API __attribute__ ((visibility ("default")))
+#	define PLD_TEST_EXPORTS_API __attribute__((visibility("default")))
 #endif
 
-constexpr const char* OP_PLD_ASSIGN   = "pldAssign";
+constexpr const char* OP_PLD_ASSIGN = "pldAssign";
 constexpr const char* OP_PLD_GENERATE = "pldGenerate";

--- a/src/palladio/PrimitiveClassifier.cpp
+++ b/src/palladio/PrimitiveClassifier.cpp
@@ -17,12 +17,12 @@
 #include "PrimitiveClassifier.h"
 #include "NodeParameter.h"
 
-
 PrimitiveClassifier::PrimitiveClassifier(SOP_Node* node, const GA_Detail* detail, const OP_Context& context) {
 	get(node, detail, context);
 }
 
-void PrimitiveClassifier::updateFromPrimitive(PrimitiveClassifier& derived, const GA_Detail* detail, const GA_Primitive* p) const {
+void PrimitiveClassifier::updateFromPrimitive(PrimitiveClassifier& derived, const GA_Detail* detail,
+                                              const GA_Primitive* p) const {
 	const GA_ROAttributeRef primClsAttrNameRef = detail->findPrimitiveAttribute(PLD_PRIM_CLS_NAME);
 	if (primClsAttrNameRef.isValid()) {
 		const GA_ROHandleS nameH(primClsAttrNameRef);

--- a/src/palladio/PrimitiveClassifier.h
+++ b/src/palladio/PrimitiveClassifier.h
@@ -16,18 +16,17 @@
 
 #pragma once
 
-#include "SOP/SOP_Node.h"
-#include "OP/OP_Context.h"
 #include "GA/GA_Handle.h"
 #include "GA/GA_Types.h"
+#include "OP/OP_Context.h"
+#include "SOP/SOP_Node.h"
 #include "UT/UT_String.h"
-
 
 const UT_String PLD_PRIM_CLS_NAME = "pldPrimClsName";
 
 class PrimitiveClassifier {
 public:
-	UT_String    name;
+	UT_String name;
 	GA_RWHandleS clsAttrNameH;
 
 	PrimitiveClassifier() = default;

--- a/src/palladio/PrimitivePartition.cpp
+++ b/src/palladio/PrimitivePartition.cpp
@@ -15,17 +15,15 @@
  */
 
 #include "PrimitivePartition.h"
-#include "PrimitiveClassifier.h"
 #include "LogHandler.h"
-
+#include "PrimitiveClassifier.h"
 
 namespace {
 
-constexpr bool  DBG               = false;
+constexpr bool DBG = false;
 constexpr int32 INVALID_CLS_VALUE = -1;
 
 } // namespace
-
 
 PrimitivePartition::PrimitivePartition(const GA_Detail* detail, const PrimitiveClassifier& primCls) {
 	const GA_Primitive* prim = nullptr;
@@ -35,7 +33,8 @@ PrimitivePartition::PrimitivePartition(const GA_Detail* detail, const PrimitiveC
 }
 
 void PrimitivePartition::add(const GA_Detail* detail, const PrimitiveClassifier& primCls, const GA_Primitive* p) {
-	if (DBG) LOG_DBG << "      adding prim: " << detail->primitiveIndex(p->getMapOffset());
+	if (DBG)
+		LOG_DBG << "      adding prim: " << detail->primitiveIndex(p->getMapOffset());
 
 	PrimitiveClassifier updatedPrimCls;
 	primCls.updateFromPrimitive(updatedPrimCls, detail, p);
@@ -49,24 +48,28 @@ void PrimitivePartition::add(const GA_Detail* detail, const PrimitiveClassifier&
 			if (sc == GA_STORECLASS_STRING || sc == GA_STORECLASS_INT)
 				primClsAttrRef = r; // we found the primitive classifier attribute itself
 			else
-				LOG_WRN << "Ignoring primitive classifier '" << r->getName() << "', it is neither of type string or int";
+				LOG_WRN << "Ignoring primitive classifier '" << r->getName()
+				        << "', it is neither of type string or int";
 		}
 	}
 
 	// try to read actual attr value and classify primitive
 	if (primClsAttrRef.isInvalid()) {
 		mPrimitives[INVALID_CLS_VALUE].push_back(p);
-		if (DBG) LOG_DBG << "       missing cls name: adding prim to fallback shape!";
+		if (DBG)
+			LOG_DBG << "       missing cls name: adding prim to fallback shape!";
 	}
 	else if (primClsAttrRef.isInt()) {
 		const GA_ROHandleI av(primClsAttrRef);
 		if (av.isValid()) {
 			const int32 v = av.get(p->getMapOffset());
-			if (DBG) LOG_DBG << "        got int classifier value: " << v;
+			if (DBG)
+				LOG_DBG << "        got int classifier value: " << v;
 			mPrimitives[v].push_back(p);
 		}
 		else {
-			if (DBG) LOG_DBG << "        int: invalid handle!";
+			if (DBG)
+				LOG_DBG << "        int: invalid handle!";
 		}
 	}
 	else if (primClsAttrRef.isString()) {
@@ -74,7 +77,8 @@ void PrimitivePartition::add(const GA_Detail* detail, const PrimitiveClassifier&
 		if (av.isValid()) {
 			const char* v = av.get(p->getMapOffset());
 			if (v) {
-				if (DBG) LOG_DBG << "        got string classifier value: " << v;
+				if (DBG)
+					LOG_DBG << "        got string classifier value: " << v;
 				mPrimitives[UT_String(v)].push_back(p);
 			}
 			else {
@@ -83,10 +87,12 @@ void PrimitivePartition::add(const GA_Detail* detail, const PrimitiveClassifier&
 			}
 		}
 		else {
-			if (DBG) LOG_DBG << "        string: invalid handle!";
+			if (DBG)
+				LOG_DBG << "        string: invalid handle!";
 		}
 	}
 	else {
-		if (DBG) LOG_DBG << "        wrong type!";
+		if (DBG)
+			LOG_DBG << "        wrong type!";
 	}
 }

--- a/src/palladio/PrimitivePartition.h
+++ b/src/palladio/PrimitivePartition.h
@@ -18,9 +18,9 @@
 
 #include "NodeParameter.h"
 
-#include "SOP/SOP_Node.h"
 #include "GA/GA_Primitive.h"
 #include "GU/GU_Detail.h"
+#include "SOP/SOP_Node.h"
 
 // clang-format off
 #include "BoostRedirect.h"
@@ -30,14 +30,13 @@
 #include <vector>
 #include <map>
 
-
 class PrimitiveClassifier;
 
 class PrimitivePartition {
 public:
 	using ClassifierValueType = PLD_BOOST_NS::variant<UT_String, int32>;
-	using PrimitiveVector     = std::vector<const GA_Primitive*>;
-	using PartitionMap        = std::map<ClassifierValueType, PrimitiveVector>;
+	using PrimitiveVector = std::vector<const GA_Primitive*>;
+	using PartitionMap = std::map<ClassifierValueType, PrimitiveVector>;
 
 	PartitionMap mPrimitives;
 

--- a/src/palladio/PrimitivePartition.h
+++ b/src/palladio/PrimitivePartition.h
@@ -22,8 +22,10 @@
 #include "GA/GA_Primitive.h"
 #include "GU/GU_Detail.h"
 
+// clang-format off
 #include "BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/variant.hpp)
+// clang-format on
 
 #include <vector>
 #include <map>

--- a/src/palladio/ResolveMapCache.h
+++ b/src/palladio/ResolveMapCache.h
@@ -18,8 +18,10 @@
 
 #include "Utils.h"
 
+// clang-format off
 #include "BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/filesystem.hpp)
+// clang-format on
 
 #include <map>
 #include <chrono>

--- a/src/palladio/ResolveMapCache.h
+++ b/src/palladio/ResolveMapCache.h
@@ -26,12 +26,11 @@
 #include <map>
 #include <chrono>
 
-
 class ResolveMapCache {
 public:
 	using KeyType = std::string;
 
-	explicit ResolveMapCache(const PLD_BOOST_NS::filesystem::path& unpackPath) : mRPKUnpackPath{unpackPath} { }
+	explicit ResolveMapCache(const PLD_BOOST_NS::filesystem::path& unpackPath) : mRPKUnpackPath{unpackPath} {}
 	ResolveMapCache(const ResolveMapCache&) = delete;
 	ResolveMapCache(ResolveMapCache&&) = delete;
 	ResolveMapCache& operator=(ResolveMapCache const&) = delete;

--- a/src/palladio/SOPAssign.cpp
+++ b/src/palladio/SOPAssign.cpp
@@ -28,9 +28,10 @@
 
 #include "UT/UT_Interrupt.h"
 
+// clang-format off
 #include "BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/algorithm/string.hpp)
-
+// clang-format on
 
 namespace {
 

--- a/src/palladio/SOPAssign.cpp
+++ b/src/palladio/SOPAssign.cpp
@@ -16,13 +16,13 @@
 
 #include "SOPAssign.h"
 #include "AttrEvalCallbacks.h"
-#include "PrimitiveClassifier.h"
-#include "ShapeGenerator.h"
-#include "ShapeData.h"
-#include "ModelConverter.h"
-#include "NodeParameter.h"
 #include "LogHandler.h"
+#include "ModelConverter.h"
 #include "MultiWatch.h"
+#include "NodeParameter.h"
+#include "PrimitiveClassifier.h"
+#include "ShapeData.h"
+#include "ShapeGenerator.h"
 
 #include "prt/API.h"
 
@@ -35,7 +35,7 @@
 
 namespace {
 
-constexpr bool           DBG                     = false;
+constexpr bool DBG = false;
 constexpr const wchar_t* ENCODER_ID_CGA_EVALATTR = L"com.esri.prt.core.AttributeEvalEncoder";
 
 AttributeMapUPtr getValidEncoderInfo(const wchar_t* encID) {
@@ -61,21 +61,17 @@ RuleFileInfoUPtr getRuleFileInfo(const MainAttributes& ma, const ResolveMapSPtr&
 	return rfi;
 }
 
-bool evaluateDefaultRuleAttributes(
-		const GU_Detail* detail,
-		ShapeData& shapeData,
-		const ShapeConverterUPtr& shapeConverter,
-		const PRTContextUPtr& prtCtx
-) {
+bool evaluateDefaultRuleAttributes(const GU_Detail* detail, ShapeData& shapeData,
+                                   const ShapeConverterUPtr& shapeConverter, const PRTContextUPtr& prtCtx) {
 	WA("all");
 
 	assert(shapeData.isValid());
 
 	// setup encoder options for attribute evaluation encoder
-	constexpr const wchar_t* encs[] = { ENCODER_ID_CGA_EVALATTR };
+	constexpr const wchar_t* encs[] = {ENCODER_ID_CGA_EVALATTR};
 	constexpr size_t encsCount = sizeof(encs) / sizeof(encs[0]);
 	const AttributeMapUPtr encOpts = getValidEncoderInfo(ENCODER_ID_CGA_EVALATTR);
-	const prt::AttributeMap* encsOpts[] = { encOpts.get() };
+	const prt::AttributeMap* encsOpts[] = {encOpts.get()};
 
 	const size_t numShapes = shapeData.getInitialShapeBuilders().size();
 
@@ -93,27 +89,24 @@ bool evaluateDefaultRuleAttributes(
 		// try to get a resolve map
 		ResolveMapSPtr resolveMap = prtCtx->getResolveMap(ma.mRPK);
 		if (!resolveMap) {
-			LOG_WRN << "Could not create resolve map from rpk " << ma.mRPK << ", aborting default rule attribute evaluation";
+			LOG_WRN << "Could not create resolve map from rpk " << ma.mRPK
+			        << ", aborting default rule attribute evaluation";
 			return false;
 		}
 
 		ruleFileInfos[isIdx] = getRuleFileInfo(ma, resolveMap, prtCtx->mPRTCache.get());
 
 		const std::wstring shapeName = L"shape_" + std::to_wstring(isIdx);
-		if (DBG) LOG_DBG << "evaluating attrs for shape: " << shapeName;
+		if (DBG)
+			LOG_DBG << "evaluating attrs for shape: " << shapeName;
 
 		// persist rule attributes even if empty (need to live until prt::generate is done)
 		AttributeMapBuilderUPtr amb(prt::AttributeMapBuilder::create());
 		AttributeMapUPtr ruleAttr(amb->createAttributeMap());
 
 		auto& isb = shapeData.getInitialShapeBuilder(isIdx);
-		isb->setAttributes(
-				ma.mRuleFile.c_str(),
-				ma.mStartRule.c_str(),
-				shapeData.getInitialShapeRandomSeed(isIdx),
-				shapeName.c_str(),
-				ruleAttr.get(),
-				resolveMap.get());
+		isb->setAttributes(ma.mRuleFile.c_str(), ma.mStartRule.c_str(), shapeData.getInitialShapeRandomSeed(isIdx),
+		                   shapeName.c_str(), ruleAttr.get(), resolveMap.get());
 
 		prt::Status status = prt::STATUS_UNSPECIFIED_ERROR;
 		const prt::InitialShape* initialShape = isb->createInitialShapeAndReset(&status);
@@ -131,7 +124,8 @@ bool evaluateDefaultRuleAttributes(
 	const prt::Status stat = prt::generate(is.data(), is.size(), nullptr, encs, encsCount, encsOpts, &aec,
 	                                       prtCtx->mPRTCache.get(), nullptr, nullptr, nullptr);
 	if (stat != prt::STATUS_OK) {
-		LOG_ERR << "assign: prt::generate() failed with status: '" << prt::getStatusDescription(stat) << "' (" << stat << ")";
+		LOG_ERR << "assign: prt::generate() failed with status: '" << prt::getStatusDescription(stat) << "' (" << stat
+		        << ")";
 	}
 
 	assert(shapeData.isValid());
@@ -141,9 +135,8 @@ bool evaluateDefaultRuleAttributes(
 
 } // namespace
 
-
 SOPAssign::SOPAssign(const PRTContextUPtr& pCtx, OP_Network* net, const char* name, OP_Operator* op)
-: SOP_Node(net, name, op), mPRTCtx(pCtx), mShapeConverter(new ShapeConverter()) { }
+    : SOP_Node(net, name, op), mPRTCtx(pCtx), mShapeConverter(new ShapeConverter()) {}
 
 OP_ERROR SOPAssign::cookMySop(OP_Context& context) {
 	WA_NEW_LAP
@@ -176,10 +169,10 @@ OP_ERROR SOPAssign::cookMySop(OP_Context& context) {
 	return error();
 }
 
-void SOPAssign::opChanged(OP_EventType reason, void *data) {
-   SOP_Node::opChanged(reason, data);
+void SOPAssign::opChanged(OP_EventType reason, void* data) {
+	SOP_Node::opChanged(reason, data);
 
-   // trigger recook on name change, we use the node name in various output places
-   if (reason == OP_NAME_CHANGED)
-	   forceRecook();
+	// trigger recook on name change, we use the node name in various output places
+	if (reason == OP_NAME_CHANGED)
+		forceRecook();
 }

--- a/src/palladio/SOPAssign.h
+++ b/src/palladio/SOPAssign.h
@@ -21,14 +21,17 @@
 
 #include "SOP/SOP_Node.h"
 
-
 class SOPAssign : public SOP_Node {
 public:
-	SOPAssign(const PRTContextUPtr& pCtx, OP_Network *net, const char *name, OP_Operator *op);
+	SOPAssign(const PRTContextUPtr& pCtx, OP_Network* net, const char* name, OP_Operator* op);
 	~SOPAssign() override = default;
 
-	const PRTContextUPtr& getPRTCtx() const { return mPRTCtx; }
-	const PLD_BOOST_NS::filesystem::path& getRPK() const { return mShapeConverter->mDefaultMainAttributes.mRPK; }
+	const PRTContextUPtr& getPRTCtx() const {
+		return mPRTCtx;
+	}
+	const PLD_BOOST_NS::filesystem::path& getRPK() const {
+		return mShapeConverter->mDefaultMainAttributes.mRPK;
+	}
 
 	void opChanged(OP_EventType reason, void* data = nullptr) override;
 
@@ -37,5 +40,5 @@ protected:
 
 private:
 	const PRTContextUPtr& mPRTCtx;
-	ShapeConverterUPtr    mShapeConverter;
+	ShapeConverterUPtr mShapeConverter;
 };

--- a/src/palladio/SOPGenerate.cpp
+++ b/src/palladio/SOPGenerate.cpp
@@ -15,23 +15,22 @@
  */
 
 #include "SOPGenerate.h"
-#include "NodeParameter.h"
-#include "ShapeGenerator.h"
-#include "ShapeData.h"
-#include "PrimitiveClassifier.h"
 #include "ModelConverter.h"
 #include "MultiWatch.h"
+#include "NodeParameter.h"
+#include "PrimitiveClassifier.h"
+#include "ShapeData.h"
+#include "ShapeGenerator.h"
 
 #include "UT/UT_Interrupt.h"
 
-#include <future>
 #include <algorithm>
-
+#include <future>
 
 namespace {
 
-constexpr const wchar_t* FILE_CGA_ERROR       = L"CGAErrors.txt";
-constexpr const wchar_t* FILE_CGA_PRINT       = L"CGAPrint.txt";
+constexpr const wchar_t* FILE_CGA_ERROR = L"CGAErrors.txt";
+constexpr const wchar_t* FILE_CGA_PRINT = L"CGAPrint.txt";
 
 constexpr const wchar_t* ENCODER_ID_CGA_ERROR = L"com.esri.prt.core.CGAErrorEncoder";
 constexpr const wchar_t* ENCODER_ID_CGA_PRINT = L"com.esri.prt.core.CGAPrintEncoder";
@@ -40,10 +39,8 @@ const PrimitiveClassifier DEFAULT_PRIMITIVE_CLASSIFIER;
 
 } // namespace
 
-
 SOPGenerate::SOPGenerate(const PRTContextUPtr& pCtx, OP_Network* net, const char* name, OP_Operator* op)
-: SOP_Node(net, name, op), mPRTCtx(pCtx)
-{
+    : SOP_Node(net, name, op), mPRTCtx(pCtx) {
 	AttributeMapBuilderUPtr optionsBuilder(prt::AttributeMapBuilder::create());
 
 	optionsBuilder->setString(L"name", FILE_CGA_ERROR);
@@ -62,8 +59,8 @@ SOPGenerate::SOPGenerate(const PRTContextUPtr& pCtx, OP_Network* net, const char
 bool SOPGenerate::handleParams(OP_Context& context) {
 	const auto now = context.getTime();
 	const bool emitAttributes = (evalInt(GenerateNodeParams::EMIT_ATTRS.getToken(), 0, now) > 0);
-	const bool emitMaterial   = (evalInt(GenerateNodeParams::EMIT_MATERIAL.getToken(), 0, now) > 0);
-	const bool emitReports    = (evalInt(GenerateNodeParams::EMIT_REPORTS.getToken(), 0, now) > 0);
+	const bool emitMaterial = (evalInt(GenerateNodeParams::EMIT_MATERIAL.getToken(), 0, now) > 0);
+	const bool emitReports = (evalInt(GenerateNodeParams::EMIT_REPORTS.getToken(), 0, now) > 0);
 
 	AttributeMapBuilderUPtr optionsBuilder(prt::AttributeMapBuilder::create());
 	optionsBuilder->setBool(EO_EMIT_ATTRIBUTES, emitAttributes);
@@ -74,8 +71,8 @@ bool SOPGenerate::handleParams(OP_Context& context) {
 	if (!mHoudiniEncoderOptions)
 		return false;
 
-	mAllEncoders = { ENCODER_ID_HOUDINI, ENCODER_ID_CGA_ERROR, ENCODER_ID_CGA_PRINT };
-	mAllEncoderOptions = { mHoudiniEncoderOptions.get(), mCGAErrorOptions.get(), mCGAPrintOptions.get() };
+	mAllEncoders = {ENCODER_ID_HOUDINI, ENCODER_ID_CGA_ERROR, ENCODER_ID_CGA_PRINT};
+	mAllEncoderOptions = {mHoudiniEncoderOptions.get(), mCGAErrorOptions.get(), mCGAPrintOptions.get()};
 
 	return true;
 }
@@ -83,26 +80,21 @@ bool SOPGenerate::handleParams(OP_Context& context) {
 namespace {
 
 enum class BatchMode { OCCLUSION, GENERATION };
-const std::vector<std::string> BATCH_MODE_NAMES = { "occlusion", "generation" };
+const std::vector<std::string> BATCH_MODE_NAMES = {"occlusion", "generation"};
 
-std::vector<prt::Status> batchGenerate(BatchMode mode,
-                                       size_t nThreads,
-                                       std::vector<ModelConverterUPtr>& hg,
-                                       size_t isRangeSize,
-                                       const InitialShapeNOPtrVector& is,
+std::vector<prt::Status> batchGenerate(BatchMode mode, size_t nThreads, std::vector<ModelConverterUPtr>& hg,
+                                       size_t isRangeSize, const InitialShapeNOPtrVector& is,
                                        const std::vector<const wchar_t*>& allEncoders,
                                        const AttributeMapNOPtrVector& allEncoderOptions,
                                        std::vector<prt::OcclusionSet::Handle>& occlusionHandles,
-                                       OcclusionSetUPtr& occlusionSet,
-                                       CacheObjectUPtr& prtCache,
-                                       const AttributeMapUPtr& genOpts)
-{
+                                       OcclusionSetUPtr& occlusionSet, CacheObjectUPtr& prtCache,
+                                       const AttributeMapUPtr& genOpts) {
 	std::vector<prt::Status> batchStatus(nThreads, prt::STATUS_UNSPECIFIED_ERROR);
 
 	std::vector<std::future<void>> futures;
 	futures.reserve(nThreads);
 	for (int8_t ti = 0; ti < nThreads; ti++) {
-		auto f = std::async(std::launch::async, [&,ti] { // capture thread index by value, else we have is range chaos
+		auto f = std::async(std::launch::async, [&, ti] { // capture thread index by value, else we have is range chaos
 			const size_t isStartPos = ti * isRangeSize;
 			const size_t isPastEndPos = (ti < nThreads - 1) ? (ti + 1) * isRangeSize : is.size();
 			const size_t isActualRangeSize = isPastEndPos - isStartPos;
@@ -113,8 +105,8 @@ std::vector<prt::Status> batchGenerate(BatchMode mode,
 
 			switch (mode) {
 				case BatchMode::OCCLUSION: {
-					batchStatus[ti] = prt::generateOccluders(isRangeStart, isActualRangeSize, isOcclRangeStart,
-					                                         nullptr, 0, nullptr, hg[ti].get(), prtCache.get(),
+					batchStatus[ti] = prt::generateOccluders(isRangeStart, isActualRangeSize, isOcclRangeStart, nullptr,
+					                                         0, nullptr, hg[ti].get(), prtCache.get(),
 					                                         occlusionSet.get(), genOpts.get());
 					break;
 				}
@@ -127,9 +119,8 @@ std::vector<prt::Status> batchGenerate(BatchMode mode,
 			}
 
 			if (batchStatus[ti] != prt::STATUS_OK) {
-			    LOG_WRN << "batch mode " << BATCH_MODE_NAMES[(int)mode] << " failed with status: '"
-			            << prt::getStatusDescription(batchStatus[ti]) << "' ("
-			            << batchStatus[ti] << ")";
+				LOG_WRN << "batch mode " << BATCH_MODE_NAMES[(int)mode] << " failed with status: '"
+				        << prt::getStatusDescription(batchStatus[ti]) << "' (" << batchStatus[ti] << ")";
 			}
 
 		});
@@ -184,15 +175,17 @@ OP_ERROR SOPGenerate::cookMySop(OP_Context& context) {
 
 			// prt requires one callback instance per generate call
 			std::vector<ModelConverterUPtr> hg(nThreads);
-			std::generate(hg.begin(), hg.end(), [this, &groupCreation, &initialShapeStatus, &progress]() -> ModelConverterUPtr {
-				return ModelConverterUPtr(new ModelConverter(gdp, groupCreation, initialShapeStatus, &progress));
-			});
+			std::generate(hg.begin(), hg.end(),
+			              [this, &groupCreation, &initialShapeStatus, &progress]() -> ModelConverterUPtr {
+				              return ModelConverterUPtr(
+				                      new ModelConverter(gdp, groupCreation, initialShapeStatus, &progress));
+			              });
 
 			std::vector<prt::OcclusionSet::Handle> occlusionHandles(is.size());
 			OcclusionSetUPtr occlusionSet{prt::OcclusionSet::create()};
 
-			LOG_INF << getName() << ": calling generate: #initial shapes = " << is.size() << ", #threads = "
-			        << nThreads << ", initial shapes per thread = " << isRangeSize;
+			LOG_INF << getName() << ": calling generate: #initial shapes = " << is.size() << ", #threads = " << nThreads
+			        << ", initial shapes per thread = " << isRangeSize;
 
 			batchGenerate(BatchMode::OCCLUSION, nThreads, hg, isRangeSize, is, mAllEncoders, mAllEncoderOptions,
 			              occlusionHandles, occlusionSet, mPRTCtx->mPRTCache, mGenerateOptions);
@@ -221,10 +214,10 @@ OP_ERROR SOPGenerate::cookMySop(OP_Context& context) {
 	return error();
 }
 
-void SOPGenerate::opChanged(OP_EventType reason, void *data) {
-   SOP_Node::opChanged(reason, data);
+void SOPGenerate::opChanged(OP_EventType reason, void* data) {
+	SOP_Node::opChanged(reason, data);
 
-   // trigger recook on name change, we use the node name in various output places
-   if (reason == OP_NAME_CHANGED)
-	   forceRecook();
+	// trigger recook on name change, we use the node name in various output places
+	if (reason == OP_NAME_CHANGED)
+		forceRecook();
 }

--- a/src/palladio/SOPGenerate.h
+++ b/src/palladio/SOPGenerate.h
@@ -16,34 +16,33 @@
 
 #pragma once
 
+#include "LogHandler.h"
 #include "PRTContext.h"
 #include "ShapeConverter.h"
-#include "LogHandler.h"
 #include "Utils.h"
 
 #include "SOP/SOP_Node.h"
 
-
 class SOPGenerate : public SOP_Node {
 public:
-	SOPGenerate(const PRTContextUPtr& pCtx, OP_Network *net, const char *name, OP_Operator *op);
+	SOPGenerate(const PRTContextUPtr& pCtx, OP_Network* net, const char* name, OP_Operator* op);
 	~SOPGenerate() override = default;
 
 	void opChanged(OP_EventType reason, void* data = nullptr) override;
 
 protected:
-	OP_ERROR cookMySop(OP_Context &context) override;
+	OP_ERROR cookMySop(OP_Context& context) override;
 
 private:
 	bool handleParams(OP_Context& context);
 
 private:
-	const PRTContextUPtr&       mPRTCtx;
+	const PRTContextUPtr& mPRTCtx;
 
-	AttributeMapUPtr            mHoudiniEncoderOptions;
-	AttributeMapUPtr            mCGAPrintOptions;
-	AttributeMapUPtr            mCGAErrorOptions;
+	AttributeMapUPtr mHoudiniEncoderOptions;
+	AttributeMapUPtr mCGAPrintOptions;
+	AttributeMapUPtr mCGAErrorOptions;
 	std::vector<const wchar_t*> mAllEncoders;
-	AttributeMapNOPtrVector     mAllEncoderOptions;
-	AttributeMapUPtr            mGenerateOptions;
+	AttributeMapNOPtrVector mAllEncoderOptions;
+	AttributeMapUPtr mGenerateOptions;
 };

--- a/src/palladio/ShapeConverter.cpp
+++ b/src/palladio/ShapeConverter.cpp
@@ -26,11 +26,12 @@
 #include "GEO/GEO_PrimPolySoup.h"
 #include "UT/UT_String.h"
 
+// clang-format off
 #include "BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/variant.hpp)
 #include PLD_BOOST_INCLUDE(/algorithm/string.hpp)
 #include PLD_BOOST_INCLUDE(/functional/hash.hpp)
-
+// clang-format on
 
 namespace {
 

--- a/src/palladio/ShapeConverter.cpp
+++ b/src/palladio/ShapeConverter.cpp
@@ -15,15 +15,15 @@
  */
 
 #include "ShapeConverter.h"
-#include "ShapeData.h"
-#include "PrimitiveClassifier.h"
 #include "AttributeConversion.h"
 #include "LogHandler.h"
 #include "MultiWatch.h"
+#include "PrimitiveClassifier.h"
+#include "ShapeData.h"
 
-#include "GU/GU_Detail.h"
 #include "GA/GA_PageHandle.h"
 #include "GEO/GEO_PrimPolySoup.h"
+#include "GU/GU_Detail.h"
 #include "UT/UT_String.h"
 
 // clang-format off
@@ -46,7 +46,7 @@ struct ConversionHelper {
 	std::vector<uint32_t> indices;
 	std::vector<uint32_t> faceCounts;
 	std::vector<uint32_t> holes;
-	std::vector<UV>       uvSets;
+	std::vector<UV> uvSets;
 
 	const std::vector<double>& coords;
 	const std::vector<GA_ROHandleV2D>& uvHandles;
@@ -58,13 +58,14 @@ struct ConversionHelper {
 	InitialShapeBuilderUPtr createInitialShape() const {
 		InitialShapeBuilderUPtr isb(prt::InitialShapeBuilder::create());
 
-		isb->setGeometry(coords.data(), coords.size(), indices.data(), indices.size(),
-		                 faceCounts.data(), faceCounts.size(), holes.data(), holes.size());
+		isb->setGeometry(coords.data(), coords.size(), indices.data(), indices.size(), faceCounts.data(),
+		                 faceCounts.size(), holes.data(), holes.size());
 
 		for (size_t u = 0; u < uvHandles.size(); u++) {
 			const auto& uvSet = uvSets[u];
 			if (!uvHandles[u].isInvalid() && !uvSet.uvs.empty()) {
-				isb->setUVs(uvSet.uvs.data(), uvSet.uvs.size(), uvSet.idx.data(), uvSet.idx.size(), faceCounts.data(), faceCounts.size(), u);
+				isb->setUVs(uvSet.uvs.data(), uvSet.uvs.size(), uvSet.idx.data(), uvSet.idx.size(), faceCounts.data(),
+				            faceCounts.size(), u);
 			}
 		}
 
@@ -73,14 +74,15 @@ struct ConversionHelper {
 };
 
 // transfer texture coordinates
-const std::vector<std::string> UV_ATTR_NAMES{
-		"uv", "uv1", "uv2", "uv3", "uv4", "uv5"
+const std::vector<std::string> UV_ATTR_NAMES {
+	"uv", "uv1", "uv2", "uv3", "uv4", "uv5"
 #if PRT_VERSION_MAJOR > 1
-		, "uv6", "uv7", "uv8", "uv9"
+	        ,
+	        "uv6", "uv7", "uv8", "uv9"
 #endif
 };
 
-template<typename P>
+template <typename P>
 void convertPolygon(ConversionHelper& ch, const P& p, const std::vector<GA_ROHandleV2D>& uvHandles) {
 	const GA_Size vtxCnt = p.getVertexCount();
 
@@ -88,7 +90,8 @@ void convertPolygon(ConversionHelper& ch, const P& p, const std::vector<GA_ROHan
 
 	for (GA_Size i = vtxCnt - 1; i >= 0; i--) {
 		ch.indices.push_back(static_cast<uint32_t>(p.getPointIndex(i)));
-		if (DBG) LOG_DBG << "      vtx " << i << ": point idx = " << p.getPointIndex(i);
+		if (DBG)
+			LOG_DBG << "      vtx " << i << ": point idx = " << p.getPointIndex(i);
 	}
 
 	for (size_t u = 0; u < uvHandles.size(); u++) {
@@ -104,22 +107,23 @@ void convertPolygon(ConversionHelper& ch, const P& p, const std::vector<GA_ROHan
 			uvSet.uvs.push_back(v.x());
 			uvSet.uvs.push_back(v.y());
 			uvSet.idx.push_back(uvSet.idx.size());
-			if (DBG) LOG_DBG << "     uv " << i << ": " << v.x() << ", " << v.y();
+			if (DBG)
+				LOG_DBG << "     uv " << i << ": " << v.x() << ", " << v.y();
 		}
 	}
 }
 
 std::array<double, 3> getCentroid(const std::vector<double>& coords, const ConversionHelper& ch) {
-	std::array<double, 3> centroid = { 0.0, 0.0, 0.0 };
+	std::array<double, 3> centroid = {0.0, 0.0, 0.0};
 	for (size_t i = 0; i < ch.indices.size(); i++) {
 		auto idx = ch.indices[i];
 		centroid[0] += coords[3 * idx + 0];
 		centroid[1] += coords[3 * idx + 1];
 		centroid[2] += coords[3 * idx + 2];
 	}
-	centroid[0] /= (double) ch.indices.size();
-	centroid[1] /= (double) ch.indices.size();
-	centroid[2] /= (double) ch.indices.size();
+	centroid[0] /= (double)ch.indices.size();
+	centroid[1] /= (double)ch.indices.size();
+	centroid[2] /= (double)ch.indices.size();
 	return centroid;
 }
 
@@ -168,14 +172,14 @@ struct MainAttributeHandles {
 		GA_RWAttributeRef styleRef(detail->addStringTuple(GA_ATTRIB_PRIMITIVE, PLD_STYLE, 1));
 		style.bind(styleRef);
 
-		GA_RWAttributeRef seedRef(detail->addIntTuple(GA_ATTRIB_PRIMITIVE, PLD_RANDOM_SEED, 1, GA_Defaults(0), nullptr, nullptr, GA_STORE_INT32));
+		GA_RWAttributeRef seedRef(detail->addIntTuple(GA_ATTRIB_PRIMITIVE, PLD_RANDOM_SEED, 1, GA_Defaults(0), nullptr,
+		                                              nullptr, GA_STORE_INT32));
 		seed.bind(seedRef);
 	}
 };
 
-void ShapeConverter::get(const GU_Detail* detail, const PrimitiveClassifier& primCls,
-                         ShapeData& shapeData, const PRTContextUPtr& prtCtx)
-{
+void ShapeConverter::get(const GU_Detail* detail, const PrimitiveClassifier& primCls, ShapeData& shapeData,
+                         const PRTContextUPtr& prtCtx) {
 	WA("all");
 
 	assert(shapeData.isValid());
@@ -187,11 +191,12 @@ void ShapeConverter::get(const GU_Detail* detail, const PrimitiveClassifier& pri
 	// -- copy all coordinates
 	std::vector<double> coords;
 	assert(detail->getPointRange().getEntries() == detail->getNumPoints());
-	coords.reserve(detail->getNumPoints()*3);
+	coords.reserve(detail->getNumPoints() * 3);
 	GA_Offset ptoff;
 	GA_FOR_ALL_PTOFF(detail, ptoff) {
 		const UT_Vector3 p = detail->getPos3(ptoff);
-		if (DBG) LOG_DBG << "coords " << coords.size()/3 << ": " << p.x() << ", " << p.y() << ", " << p.z();
+		if (DBG)
+			LOG_DBG << "coords " << coords.size() / 3 << ": " << p.x() << ", " << p.y() << ", " << p.z();
 		coords.push_back(static_cast<double>(p.x()));
 		coords.push_back(static_cast<double>(p.y()));
 		coords.push_back(static_cast<double>(p.z()));
@@ -200,33 +205,38 @@ void ShapeConverter::get(const GU_Detail* detail, const PrimitiveClassifier& pri
 	// scan for uv attributes
 	std::vector<GA_ROHandleV2D> uvHandles(UV_ATTR_NAMES.size());
 	for (uint32_t uvSet = 0; uvSet < UV_ATTR_NAMES.size(); uvSet++) {
-		const std::string &attrName = UV_ATTR_NAMES[uvSet];
-		const GA_Attribute *attrib = detail->findFloatTuple(GA_ATTRIB_VERTEX, attrName, 2);
+		const std::string& attrName = UV_ATTR_NAMES[uvSet];
+		const GA_Attribute* attrib = detail->findFloatTuple(GA_ATTRIB_VERTEX, attrName, 2);
 		uvHandles[uvSet].bind(attrib);
 	}
 
 	// -- loop over all primitive partitions and create shape builders
 	uint32_t isIdx = 0;
 	for (auto pIt = partitions.cbegin(); pIt != partitions.cend(); ++pIt, ++isIdx) {
-		if (DBG) LOG_DBG << "   -- creating initial shape " << isIdx << ", prim count = " << pIt->second.size();
+		if (DBG)
+			LOG_DBG << "   -- creating initial shape " << isIdx << ", prim count = " << pIt->second.size();
 
 		ConversionHelper ch(coords, uvHandles);
 
 		// merge primitive geometry inside partition (potential multi-polygon initial shape)
-		for (const auto& prim: pIt->second) {
-			if (DBG) LOG_DBG << "   -- prim index " << prim->getMapIndex() << ", type: " << prim->getTypeName() << ", id = " << prim->getTypeId().get();
+		for (const auto& prim : pIt->second) {
+			if (DBG)
+				LOG_DBG << "   -- prim index " << prim->getMapIndex() << ", type: " << prim->getTypeName()
+				        << ", id = " << prim->getTypeId().get();
 			const auto& primType = prim->getTypeId();
 			switch (primType.get()) {
 				case GA_PRIMPOLY:
 					convertPolygon(ch, *prim, uvHandles);
 					break;
 				case GA_PRIMPOLYSOUP:
-					for (GEO_PrimPolySoup::PolygonIterator pit(static_cast<const GEO_PrimPolySoup&>(*prim)); !pit.atEnd(); ++pit) {
+					for (GEO_PrimPolySoup::PolygonIterator pit(static_cast<const GEO_PrimPolySoup&>(*prim));
+					     !pit.atEnd(); ++pit) {
 						convertPolygon(ch, pit, uvHandles);
 					}
 					break;
 				default:
-					if (DBG) LOG_DBG << "      ignoring primitive of type " << prim->getTypeName();
+					if (DBG)
+						LOG_DBG << "      ignoring primitive of type " << prim->getTypeName();
 					break;
 			}
 		} // for each primitive
@@ -251,36 +261,36 @@ void ShapeConverter::put(GU_Detail* detail, PrimitiveClassifier& primCls, const 
 		const auto& pv = shapeData.getPrimitiveMapping(isIdx);
 		const int32_t randomSeed = shapeData.getInitialShapeRandomSeed(isIdx);
 
-		for (auto& prim: pv) {
+		for (auto& prim : pv) {
 			primCls.put(prim);
 			putMainAttributes(detail, mah, prim);
 			const GA_Offset& off = prim->getMapOffset();
 			mah.seed.set(off, randomSeed);
 		} // for all primitives in initial shape
-	} // for all initial shapes
+	}     // for all initial shapes
 }
 
 void ShapeConverter::getMainAttributes(SOP_Node* node, const OP_Context& context) {
 	const fpreal now = context.getTime();
-	mDefaultMainAttributes.mRPK       = AssignNodeParams::getRPK(node, now);
-	mDefaultMainAttributes.mRuleFile  = AssignNodeParams::getRuleFile(node, now);
-	mDefaultMainAttributes.mStyle     = AssignNodeParams::getStyle(node, now);
+	mDefaultMainAttributes.mRPK = AssignNodeParams::getRPK(node, now);
+	mDefaultMainAttributes.mRuleFile = AssignNodeParams::getRuleFile(node, now);
+	mDefaultMainAttributes.mStyle = AssignNodeParams::getStyle(node, now);
 	mDefaultMainAttributes.mStartRule = AssignNodeParams::getStartRule(node, now);
 }
 
 namespace {
 
-template<typename T>
+template <typename T>
 T convert(const UT_StringHolder& s) {
 	return T{s.toStdString()};
 }
 
-template<>
+template <>
 std::wstring convert(const UT_StringHolder& s) {
 	return toUTF16FromOSNarrow(s.toStdString());
 }
 
-template<typename T>
+template <typename T>
 void tryAssign(T& v, const GA_ROAttributeRef& ref, const GA_Offset& off) {
 	if (ref.isInvalid())
 		return;
@@ -314,7 +324,8 @@ MainAttributes ShapeConverter::getMainAttributesFromPrimitive(const GU_Detail* d
 	return ma;
 }
 
-void ShapeConverter::putMainAttributes(const GU_Detail* detail, MainAttributeHandles& mah, const GA_Primitive* primitive) const {
+void ShapeConverter::putMainAttributes(const GU_Detail* detail, MainAttributeHandles& mah,
+                                       const GA_Primitive* primitive) const {
 	MainAttributes ma = getMainAttributesFromPrimitive(detail, primitive);
 
 	const GA_Offset& off = primitive->getMapOffset();

--- a/src/palladio/ShapeConverter.h
+++ b/src/palladio/ShapeConverter.h
@@ -28,7 +28,6 @@
 
 #include <string>
 
-
 class GU_Detail;
 class GA_Primitive;
 class OP_Context;
@@ -37,25 +36,25 @@ class PrimitiveClassifier;
 class MainAttributeHandles;
 class ShapeData;
 
-const UT_String PLD_RPK         = "pldRPK";
-const UT_String PLD_RULE_FILE   = "pldRuleFile";
-const UT_String PLD_START_RULE  = "pldStartRule";
-const UT_String PLD_STYLE       = "pldStyle";
+const UT_String PLD_RPK = "pldRPK";
+const UT_String PLD_RULE_FILE = "pldRuleFile";
+const UT_String PLD_START_RULE = "pldStartRule";
+const UT_String PLD_STYLE = "pldStyle";
 const UT_String PLD_RANDOM_SEED = "pldRandomSeed";
 
 enum class GroupCreation { NONE, PRIMCLS };
 
 struct MainAttributes {
 	PLD_BOOST_NS::filesystem::path mRPK;
-	std::wstring                   mRuleFile;
-	std::wstring                   mStyle;
-	std::wstring                   mStartRule;
+	std::wstring mRuleFile;
+	std::wstring mStyle;
+	std::wstring mStartRule;
 };
 
 class ShapeConverter {
 public:
-	virtual void get(const GU_Detail* detail,  const PrimitiveClassifier& primCls,
-	                 ShapeData& shapeData, const PRTContextUPtr& prtCtx);
+	virtual void get(const GU_Detail* detail, const PrimitiveClassifier& primCls, ShapeData& shapeData,
+	                 const PRTContextUPtr& prtCtx);
 	void put(GU_Detail* detail, PrimitiveClassifier& primCls, const ShapeData& shapeData) const;
 
 	void getMainAttributes(SOP_Node* node, const OP_Context& context); // TODO: integrate into get
@@ -67,4 +66,3 @@ public:
 };
 
 using ShapeConverterUPtr = std::unique_ptr<ShapeConverter>;
-

--- a/src/palladio/ShapeConverter.h
+++ b/src/palladio/ShapeConverter.h
@@ -21,8 +21,10 @@
 
 #include "UT/UT_String.h"
 
+// clang-format off
 #include "BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/filesystem/path.hpp)
+// clang-format on
 
 #include <string>
 

--- a/src/palladio/ShapeData.cpp
+++ b/src/palladio/ShapeData.cpp
@@ -16,31 +16,30 @@
 
 #include "ShapeData.h"
 
-
 namespace {
 
-const std::wstring DEFAULT_SHAPE_NAME     = L"pldShape";
+const std::wstring DEFAULT_SHAPE_NAME = L"pldShape";
 const std::wstring GROUP_NAME_LEGAL_CHARS = L"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789";
-const std::wstring INVALID_GROUP_NAME     = L"_invalid_";
+const std::wstring INVALID_GROUP_NAME = L"_invalid_";
 
 /**
  * creates initial shape and primitive group name from primitive classifier value
  */
 class NameFromPrimPart : public PLD_BOOST_NS::static_visitor<> {
 public:
-	NameFromPrimPart(std::wstring& name, const std::wstring& prefix) : mName(name), mPrefix(prefix) { }
+	NameFromPrimPart(std::wstring& name, const std::wstring& prefix) : mName(name), mPrefix(prefix) {}
 
-    void operator()(const UT_String& s) {
-        mName.assign(toUTF16FromOSNarrow(s.toStdString()));
-	    replace_all_not_of(mName, GROUP_NAME_LEGAL_CHARS);
-	    if (mName.empty()) // handle empty primCls string value
-		    mName.assign(INVALID_GROUP_NAME);
-    }
+	void operator()(const UT_String& s) {
+		mName.assign(toUTF16FromOSNarrow(s.toStdString()));
+		replace_all_not_of(mName, GROUP_NAME_LEGAL_CHARS);
+		if (mName.empty()) // handle empty primCls string value
+			mName.assign(INVALID_GROUP_NAME);
+	}
 
-    void operator()(const int32& i) {
-        mName.assign(mPrefix).append(L"_").append(std::to_wstring(i));
-	    replace_all_not_of(mName, GROUP_NAME_LEGAL_CHARS);
-    }
+	void operator()(const int32& i) {
+		mName.assign(mPrefix).append(L"_").append(std::to_wstring(i));
+		replace_all_not_of(mName, GROUP_NAME_LEGAL_CHARS);
+	}
 
 private:
 	std::wstring& mName;
@@ -49,18 +48,15 @@ private:
 
 } // namespace
 
-
 ShapeData::~ShapeData() {
-	std::for_each(mInitialShapes.begin(), mInitialShapes.end(), [](const prt::InitialShape* is){
+	std::for_each(mInitialShapes.begin(), mInitialShapes.end(), [](const prt::InitialShape* is) {
 		if (is)
 			is->destroy();
 	});
 }
 
-void ShapeData::addBuilder(InitialShapeBuilderUPtr&& isb, int32_t randomSeed,
-                           const PrimitiveNOPtrVector& primMappings,
-                           const PrimitivePartition::ClassifierValueType& clsVal)
-{
+void ShapeData::addBuilder(InitialShapeBuilderUPtr&& isb, int32_t randomSeed, const PrimitiveNOPtrVector& primMappings,
+                           const PrimitivePartition::ClassifierValueType& clsVal) {
 	mInitialShapeBuilders.emplace_back(std::move(isb));
 	mRandomSeeds.push_back(randomSeed);
 	mPrimitiveMapping.emplace_back(primMappings);

--- a/src/palladio/ShapeData.h
+++ b/src/palladio/ShapeData.h
@@ -16,15 +16,14 @@
 
 #pragma once
 
-#include "PrimitivePartition.h"
 #include "NodeParameter.h"
+#include "PrimitivePartition.h"
 #include "Utils.h"
-
 
 class ShapeData final {
 public:
 	ShapeData() = default;
-	ShapeData(const GroupCreation& gc, const std::wstring& namePrefix) : mGroupCreation(gc), mNamePrefix(namePrefix) { }
+	ShapeData(const GroupCreation& gc, const std::wstring& namePrefix) : mGroupCreation(gc), mNamePrefix(namePrefix) {}
 	ShapeData(const ShapeData&) = delete;
 	ShapeData(ShapeData&&) = delete;
 	~ShapeData();
@@ -34,31 +33,45 @@ public:
 
 	void addShape(const prt::InitialShape* is, AttributeMapBuilderUPtr&& amb, AttributeMapUPtr&& ruleAttr);
 
-	InitialShapeBuilderVector& getInitialShapeBuilders() { return mInitialShapeBuilders; }
-	int32_t getInitialShapeRandomSeed(size_t isIdx) const { return mRandomSeeds[isIdx]; }
-	InitialShapeBuilderUPtr& getInitialShapeBuilder(size_t isIdx) { return mInitialShapeBuilders[isIdx]; }
-	const PrimitiveNOPtrVector& getPrimitiveMapping(size_t isIdx) const { return mPrimitiveMapping[isIdx]; }
+	InitialShapeBuilderVector& getInitialShapeBuilders() {
+		return mInitialShapeBuilders;
+	}
+	int32_t getInitialShapeRandomSeed(size_t isIdx) const {
+		return mRandomSeeds[isIdx];
+	}
+	InitialShapeBuilderUPtr& getInitialShapeBuilder(size_t isIdx) {
+		return mInitialShapeBuilders[isIdx];
+	}
+	const PrimitiveNOPtrVector& getPrimitiveMapping(size_t isIdx) const {
+		return mPrimitiveMapping[isIdx];
+	}
 
-	AttributeMapBuilderVector& getRuleAttributeMapBuilders() { return mRuleAttributeBuilders; }
-	const AttributeMapBuilderVector& getRuleAttributeMapBuilders() const { return mRuleAttributeBuilders; }
+	AttributeMapBuilderVector& getRuleAttributeMapBuilders() {
+		return mRuleAttributeBuilders;
+	}
+	const AttributeMapBuilderVector& getRuleAttributeMapBuilders() const {
+		return mRuleAttributeBuilders;
+	}
 
 	const std::wstring& getInitialShapeName(size_t isIdx) const;
-	const InitialShapeNOPtrVector& getInitialShapes() const { return mInitialShapes; }
+	const InitialShapeNOPtrVector& getInitialShapes() const {
+		return mInitialShapes;
+	}
 
 	bool isValid() const;
 
 private:
 	std::vector<PrimitiveNOPtrVector> mPrimitiveMapping;
 
-	InitialShapeBuilderVector         mInitialShapeBuilders;
-	InitialShapeNOPtrVector           mInitialShapes;
+	InitialShapeBuilderVector mInitialShapeBuilders;
+	InitialShapeNOPtrVector mInitialShapes;
 
-	AttributeMapBuilderVector         mRuleAttributeBuilders;
-	AttributeMapVector                mRuleAttributes;
+	AttributeMapBuilderVector mRuleAttributeBuilders;
+	AttributeMapVector mRuleAttributes;
 
-	GroupCreation                     mGroupCreation = GroupCreation::NONE;
-	std::vector<std::wstring>         mInitialShapeNames;
-	std::wstring                      mNamePrefix;
+	GroupCreation mGroupCreation = GroupCreation::NONE;
+	std::vector<std::wstring> mInitialShapeNames;
+	std::wstring mNamePrefix;
 
-	std::vector<int32_t>              mRandomSeeds;
+	std::vector<int32_t> mRandomSeeds;
 };

--- a/src/palladio/ShapeGenerator.cpp
+++ b/src/palladio/ShapeGenerator.cpp
@@ -15,25 +15,24 @@
  */
 
 #include "ShapeGenerator.h"
-#include "ShapeData.h"
-#include "PrimitivePartition.h"
-#include "PrimitiveClassifier.h"
 #include "AttributeConversion.h"
 #include "LogHandler.h"
 #include "MultiWatch.h"
+#include "PrimitiveClassifier.h"
+#include "PrimitivePartition.h"
+#include "ShapeData.h"
 
 #include "GA/GA_Primitive.h"
 #include "GU/GU_Detail.h"
 
 #include <unordered_map>
 
-
 namespace {
 
 constexpr bool DBG = true;
 
-const std::set<UT_StringHolder> ATTRIBUTE_BLACKLIST = { PLD_PRIM_CLS_NAME, PLD_RPK, PLD_RULE_FILE,
-                                                        PLD_START_RULE, PLD_STYLE, PLD_RANDOM_SEED };
+const std::set<UT_StringHolder> ATTRIBUTE_BLACKLIST = {PLD_PRIM_CLS_NAME, PLD_RPK,   PLD_RULE_FILE,
+                                                       PLD_START_RULE,    PLD_STYLE, PLD_RANDOM_SEED};
 
 std::wstring getFullyQualifiedStartRule(const MainAttributes& ma) {
 	if (ma.mStartRule.find(L'$') != std::wstring::npos)
@@ -44,10 +43,8 @@ std::wstring getFullyQualifiedStartRule(const MainAttributes& ma) {
 
 } // namespace
 
-
-void ShapeGenerator::get(const GU_Detail* detail, const PrimitiveClassifier& primCls,
-                         ShapeData& shapeData, const PRTContextUPtr& prtCtx)
-{
+void ShapeGenerator::get(const GU_Detail* detail, const PrimitiveClassifier& primCls, ShapeData& shapeData,
+                         const PRTContextUPtr& prtCtx) {
 	WA("all");
 
 	// extract initial shape geometry
@@ -92,7 +89,8 @@ void ShapeGenerator::get(const GU_Detail* detail, const PrimitiveClassifier& pri
 		const auto& firstPrimitive = pv.front();
 		const auto& primitiveMapOffset = firstPrimitive->getMapOffset();
 
-		if (DBG) LOG_DBG << "   -- creating initial shape " << isIdx << ", prim count = " << pv.size();
+		if (DBG)
+			LOG_DBG << "   -- creating initial shape " << isIdx << ", prim count = " << pv.size();
 
 		// extract main attrs from first prim in initial shape prim group
 		const MainAttributes ma = getMainAttributesFromPrimitive(detail, firstPrimitive);
@@ -103,7 +101,7 @@ void ShapeGenerator::get(const GU_Detail* detail, const PrimitiveClassifier& pri
 
 		// extract primitive attributes
 		AttributeMapBuilderUPtr amb(prt::AttributeMapBuilder::create());
-		for (const auto& attr: attributes) {
+		for (const auto& attr : attributes) {
 			const GA_ROAttributeRef& ar = attr.second;
 
 			if (ar.isInvalid())
@@ -116,7 +114,8 @@ void ShapeGenerator::get(const GU_Detail* detail, const PrimitiveClassifier& pri
 					GA_ROHandleD av(ar);
 					if (av.isValid()) {
 						double v = av.get(primitiveMapOffset);
-						if (DBG) LOG_DBG << "   prim float attr: " << ar->getName() << " = " << v;
+						if (DBG)
+							LOG_DBG << "   prim float attr: " << ar->getName() << " = " << v;
 						amb->setFloat(ruleAttrName.c_str(), v);
 					}
 					break;
@@ -126,7 +125,8 @@ void ShapeGenerator::get(const GU_Detail* detail, const PrimitiveClassifier& pri
 					if (av.isValid()) {
 						const char* v = av.get(primitiveMapOffset);
 						const std::wstring wv = toUTF16FromOSNarrow(v);
-						if (DBG) LOG_DBG << "   prim string attr: " << ar->getName() << " = " << v;
+						if (DBG)
+							LOG_DBG << "   prim string attr: " << ar->getName() << " = " << v;
 						amb->setString(ruleAttrName.c_str(), wv.c_str());
 					}
 					break;
@@ -136,7 +136,8 @@ void ShapeGenerator::get(const GU_Detail* detail, const PrimitiveClassifier& pri
 					if (av.isValid()) {
 						const int v = av.get(primitiveMapOffset);
 						const bool bv = (v > 0);
-						if (DBG) LOG_DBG << "   prim bool attr: " << ar->getName() << " = " << v;
+						if (DBG)
+							LOG_DBG << "   prim bool attr: " << ar->getName() << " = " << v;
 						amb->setBool(ruleAttrName.c_str(), bv);
 					}
 					break;
@@ -146,7 +147,7 @@ void ShapeGenerator::get(const GU_Detail* detail, const PrimitiveClassifier& pri
 					break;
 				}
 			} // switch key type
-		} // for each primitive attribute
+		}     // for each primitive attribute
 
 		AttributeMapUPtr ruleAttr(amb->createAttributeMap());
 
@@ -155,19 +156,14 @@ void ShapeGenerator::get(const GU_Detail* detail, const PrimitiveClassifier& pri
 		const auto& shapeName = shapeData.getInitialShapeName(isIdx);
 		const auto fqStartRule = getFullyQualifiedStartRule(ma);
 
-		isb->setAttributes(
-				ma.mRuleFile.c_str(),
-				fqStartRule.c_str(),
-				randomSeed,
-				shapeName.c_str(),
-				ruleAttr.get(),
-				assetsMap.get()
-		);
+		isb->setAttributes(ma.mRuleFile.c_str(), fqStartRule.c_str(), randomSeed, shapeName.c_str(), ruleAttr.get(),
+		                   assetsMap.get());
 
 		prt::Status status = prt::STATUS_UNSPECIFIED_ERROR;
 		const prt::InitialShape* initialShape = isb->createInitialShapeAndReset(&status);
 		if (status == prt::STATUS_OK && initialShape != nullptr) {
-			if (DBG) LOG_DBG << objectToXML(initialShape);
+			if (DBG)
+				LOG_DBG << objectToXML(initialShape);
 			shapeData.addShape(initialShape, std::move(amb), std::move(ruleAttr));
 		}
 		else

--- a/src/palladio/ShapeGenerator.cpp
+++ b/src/palladio/ShapeGenerator.cpp
@@ -41,6 +41,10 @@ std::wstring getFullyQualifiedStartRule(const MainAttributes& ma) {
 		return ma.mStyle + L'$' + ma.mStartRule;
 }
 
+bool isArrayAttribute(const GA_ROAttributeRef& ar) {
+	return (ar.getAIFNumericArray() != nullptr) || (ar.getAIFSharedStringArray() != nullptr);
+}
+
 } // namespace
 
 void ShapeGenerator::get(const GU_Detail* detail, const PrimitiveClassifier& primCls, ShapeData& shapeData,
@@ -111,35 +115,104 @@ void ShapeGenerator::get(const GU_Detail* detail, const PrimitiveClassifier& pri
 
 			switch (ar.getStorageClass()) {
 				case GA_STORECLASS_FLOAT: {
-					GA_ROHandleD av(ar);
-					if (av.isValid()) {
-						double v = av.get(primitiveMapOffset);
-						if (DBG)
-							LOG_DBG << "   prim float attr: " << ar->getName() << " = " << v;
-						amb->setFloat(ruleAttrName.c_str(), v);
+					if (isArrayAttribute(ar)) {
+						GA_ROHandleDA av(ar);
+						if (av.isValid()) {
+							UT_Fpreal64Array v;
+							av.get(primitiveMapOffset, v);
+							if (DBG)
+								LOG_DBG << "   prim float array attr: " << ar->getName() << " = " << v;
+							amb->setFloatArray(ruleAttrName.c_str(), v.data(), v.size());
+						}
+					}
+					else {
+						GA_ROHandleD av(ar);
+						if (av.isValid()) {
+							double v = av.get(primitiveMapOffset);
+							if (DBG)
+								LOG_DBG << "   prim float attr: " << ar->getName() << " = " << v;
+							amb->setFloat(ruleAttrName.c_str(), v);
+						}
 					}
 					break;
 				}
 				case GA_STORECLASS_STRING: {
-					GA_ROHandleS av(ar);
-					if (av.isValid()) {
-						const char* v = av.get(primitiveMapOffset);
-						const std::wstring wv = toUTF16FromOSNarrow(v);
-						if (DBG)
-							LOG_DBG << "   prim string attr: " << ar->getName() << " = " << v;
-						amb->setString(ruleAttrName.c_str(), wv.c_str());
+					if (isArrayAttribute(ar)) {
+						GA_ROHandleSA av(ar);
+						if (av.isValid()) {
+							UT_StringArray v;
+							av.get(primitiveMapOffset, v);
+							if (DBG)
+								LOG_DBG << "   prim string array attr: " << ar->getName() << " = " << v;
+
+							std::vector<std::wstring> wstrings(v.size());
+							std::vector<const wchar_t*> wstringPtrs(v.size());
+							for (size_t i = 0; i < v.size(); i++) {
+								wstrings[i] = toUTF16FromOSNarrow(v[i].toStdString());
+								wstringPtrs[i] = wstrings[i].c_str();
+							}
+							amb->setStringArray(ruleAttrName.c_str(), wstringPtrs.data(), wstringPtrs.size());
+						}
+					}
+					else {
+						GA_ROHandleS av(ar);
+						if (av.isValid()) {
+							const char* v = av.get(primitiveMapOffset);
+							const std::wstring wv = toUTF16FromOSNarrow(v);
+							if (DBG)
+								LOG_DBG << "   prim string attr: " << ar->getName() << " = " << v;
+							amb->setString(ruleAttrName.c_str(), wv.c_str());
+						}
 					}
 					break;
 				}
 				case GA_STORECLASS_INT: {
-					GA_ROHandleI av(ar);
-					if (av.isValid()) {
-						const int v = av.get(primitiveMapOffset);
-						const bool bv = (v > 0);
-						if (DBG)
-							LOG_DBG << "   prim bool attr: " << ar->getName() << " = " << v;
-						amb->setBool(ruleAttrName.c_str(), bv);
+					if (isArrayAttribute(ar)) {
+						if (ar.getAIFNumericArray()->getStorage(ar.get()) == GA_STORE_INT8) {
+							GA_ROHandleIA av(ar);
+							if (av.isValid()) {
+								UT_Int32Array v; // there is no U_Int8Array
+								av.get(primitiveMapOffset, v);
+								if (DBG)
+									LOG_DBG << "   prim bool array attr: " << ar->getName() << " = " << v;
+								const std::unique_ptr<bool[]> vPtrs(new bool[v.size()]);
+								for (size_t i = 0; i < v.size(); i++)
+									vPtrs[i] = (v[i] > 0);
+								amb->setBoolArray(ruleAttrName.c_str(), vPtrs.get(), v.size());
+							}
+						}
+						else {
+							GA_ROHandleIA av(ar);
+							if (av.isValid()) {
+								UT_Int32Array v;
+								av.get(primitiveMapOffset, v);
+								if (DBG)
+									LOG_DBG << "   prim int array attr: " << ar->getName() << " = " << v;
+								amb->setIntArray(ruleAttrName.c_str(), v.data(), v.size());
+							}
+						}
 					}
+					else {
+						if (ar.getAIFTuple()->getStorage(ar.get()) == GA_STORE_INT8) {
+							GA_ROHandleI av(ar);
+							if (av.isValid()) {
+								const int v = av.get(primitiveMapOffset);
+								const bool bv = (v > 0);
+								if (DBG)
+									LOG_DBG << "   prim bool attr: " << ar->getName() << " = " << bv;
+								amb->setBool(ruleAttrName.c_str(), bv);
+							}
+						}
+						else {
+							GA_ROHandleI av(ar);
+							if (av.isValid()) {
+								const int v = av.get(primitiveMapOffset);
+								if (DBG)
+									LOG_DBG << "   prim int attr: " << ar->getName() << " = " << v;
+								amb->setInt(ruleAttrName.c_str(), v);
+							}
+						}
+					} // int
 					break;
 				}
 				default: {

--- a/src/palladio/ShapeGenerator.h
+++ b/src/palladio/ShapeGenerator.h
@@ -23,6 +23,6 @@
 class GU_Detail;
 
 struct ShapeGenerator final : ShapeConverter {
-    void get(const GU_Detail* detail, const PrimitiveClassifier& primCls,
-             ShapeData& shapeData, const PRTContextUPtr& prtCtx) override;
+	void get(const GU_Detail* detail, const PrimitiveClassifier& primCls, ShapeData& shapeData,
+	         const PRTContextUPtr& prtCtx) override;
 };

--- a/src/palladio/Utils.cpp
+++ b/src/palladio/Utils.cpp
@@ -24,9 +24,11 @@
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
+// clang-format off
 #include "BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/algorithm/string.hpp)
 #include PLD_BOOST_INCLUDE(/filesystem.hpp)
+// clang-format on
 #ifndef _WIN32
 #	pragma GCC diagnostic pop
 #endif

--- a/src/palladio/Utils.cpp
+++ b/src/palladio/Utils.cpp
@@ -33,21 +33,19 @@
 #	pragma GCC diagnostic pop
 #endif
 
-
 #ifdef _WIN32
 #	include <Windows.h>
 #else
 #	include <dlfcn.h>
 #endif
 
-
-void getCGBs(const ResolveMapSPtr& rm, std::vector<std::pair<std::wstring,std::wstring>>& cgbs) {
-	constexpr const wchar_t* PROJECT    = L"";
-	constexpr const wchar_t* PATTERN    = L"*.cgb";
-	constexpr const size_t   START_SIZE = 16 * 1024;
+void getCGBs(const ResolveMapSPtr& rm, std::vector<std::pair<std::wstring, std::wstring>>& cgbs) {
+	constexpr const wchar_t* PROJECT = L"";
+	constexpr const wchar_t* PATTERN = L"*.cgb";
+	constexpr const size_t START_SIZE = 16 * 1024;
 
 	size_t resultSize = START_SIZE;
-	auto * result = new wchar_t[resultSize]; // TODO: use std::array
+	auto* result = new wchar_t[resultSize]; // TODO: use std::array
 	rm->searchKey(PROJECT, PATTERN, result, &resultSize);
 	if (resultSize >= START_SIZE) {
 		delete[] result;
@@ -60,8 +58,9 @@ void getCGBs(const ResolveMapSPtr& rm, std::vector<std::pair<std::wstring,std::w
 
 	std::vector<std::wstring> tok;
 	PLD_BOOST_NS::split(tok, cgbList, PLD_BOOST_NS::is_any_of(L";"), PLD_BOOST_NS::algorithm::token_compress_on);
-	for(const std::wstring& t: tok) {
-		if (t.empty()) continue;
+	for (const std::wstring& t : tok) {
+		if (t.empty())
+			continue;
 		LOG_DBG << "token: '" << t << "'";
 		const wchar_t* s = rm->getString(t.c_str());
 		if (s != nullptr) {
@@ -75,7 +74,8 @@ const prt::AttributeMap* createValidatedOptions(const wchar_t* encID, const prt:
 	const EncoderInfoUPtr encInfo(prt::createEncoderInfo(encID));
 	const prt::AttributeMap* validatedOptions = nullptr;
 	const prt::AttributeMap* optionStates = nullptr;
-	const prt::Status s = encInfo->createValidatedOptionsAndStates(unvalidatedOptions, &validatedOptions, &optionStates);
+	const prt::Status s =
+	        encInfo->createValidatedOptionsAndStates(unvalidatedOptions, &validatedOptions, &optionStates);
 	if (optionStates != nullptr)
 		optionStates->destroy();
 	return (s == prt::STATUS_OK) ? validatedOptions : nullptr;
@@ -89,7 +89,7 @@ std::string objectToXML(prt::Object const* obj) {
 	std::vector<char> buffer(SIZE, ' ');
 	obj->toXML(buffer.data(), &actualSize);
 	buffer.resize(actualSize);
-	if(actualSize > SIZE)
+	if (actualSize > SIZE)
 		obj->toXML(buffer.data(), &actualSize);
 	return std::string(buffer.data());
 }
@@ -97,26 +97,26 @@ std::string objectToXML(prt::Object const* obj) {
 void getLibraryPath(PLD_BOOST_NS::filesystem::path& path, const void* func) {
 #ifdef _WIN32
 	HMODULE dllHandle = 0;
-	if(!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)func, &dllHandle)) {
+	if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)func, &dllHandle)) {
 		DWORD c = GetLastError();
 		char msg[255];
-		FormatMessage (FORMAT_MESSAGE_FROM_SYSTEM, 0, c, 0, msg, 255, 0);
+		FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, 0, c, 0, msg, 255, 0);
 		throw std::runtime_error("error while trying to get current module handle': " + std::string(msg));
 	}
 	assert(sizeof(TCHAR) == 1);
 	const size_t PATHMAXSIZE = 4096;
 	TCHAR pathA[PATHMAXSIZE];
 	DWORD pathSize = GetModuleFileName(dllHandle, pathA, PATHMAXSIZE);
-	if(pathSize == 0 || pathSize == PATHMAXSIZE) {
+	if (pathSize == 0 || pathSize == PATHMAXSIZE) {
 		DWORD c = GetLastError();
 		char msg[255];
-		FormatMessage (FORMAT_MESSAGE_FROM_SYSTEM, 0, c, 0, msg, 255, 0);
+		FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, 0, c, 0, msg, 255, 0);
 		throw std::runtime_error("error while trying to get current module path': " + std::string(msg));
 	}
 	path = pathA;
 #else /* macosx or linux */
 	Dl_info dl_info;
-	if(dladdr(func, &dl_info) == 0) {
+	if (dladdr(func, &dl_info) == 0) {
 		char* error = dlerror();
 		throw std::runtime_error("error while trying to get current module path': " + std::string(error ? error : ""));
 	}
@@ -153,7 +153,7 @@ std::string toOSNarrowFromUTF16(const std::wstring& osWString) {
 	size_t size = temp.size();
 	prt::Status status = prt::STATUS_OK;
 	prt::StringUtils::toOSNarrowFromUTF16(osWString.c_str(), temp.data(), &size, &status);
-	if(size > temp.size()) {
+	if (size > temp.size()) {
 		temp.resize(size);
 		prt::StringUtils::toOSNarrowFromUTF16(osWString.c_str(), temp.data(), &size, &status);
 	}
@@ -165,7 +165,7 @@ std::wstring toUTF16FromOSNarrow(const std::string& osString) {
 	size_t size = temp.size();
 	prt::Status status = prt::STATUS_OK;
 	prt::StringUtils::toUTF16FromOSNarrow(osString.c_str(), temp.data(), &size, &status);
-	if(size > temp.size()) {
+	if (size > temp.size()) {
 		temp.resize(size);
 		prt::StringUtils::toUTF16FromOSNarrow(osString.c_str(), temp.data(), &size, &status);
 	}
@@ -178,7 +178,7 @@ std::string toUTF8FromOSNarrow(const std::string& osString) {
 	size_t size = temp.size();
 	prt::Status status = prt::STATUS_OK;
 	prt::StringUtils::toUTF8FromUTF16(utf16String.c_str(), temp.data(), &size, &status);
-	if(size > temp.size()) {
+	if (size > temp.size()) {
 		temp.resize(size);
 		prt::StringUtils::toUTF8FromUTF16(utf16String.c_str(), temp.data(), &size, &status);
 	}
@@ -197,11 +197,11 @@ std::wstring toFileURI(const PLD_BOOST_NS::filesystem::path& p) {
 }
 
 std::wstring percentEncode(const std::string& utf8String) {
-	std::vector<char> temp(2*utf8String.size());
+	std::vector<char> temp(2 * utf8String.size());
 	size_t size = temp.size();
 	prt::Status status = prt::STATUS_OK;
 	prt::StringUtils::percentEncode(utf8String.c_str(), temp.data(), &size, &status);
-	if(size > temp.size()) {
+	if (size > temp.size()) {
 		temp.resize(size);
 		prt::StringUtils::percentEncode(utf8String.c_str(), temp.data(), &size, &status);
 	}
@@ -209,7 +209,7 @@ std::wstring percentEncode(const std::string& utf8String) {
 	std::vector<wchar_t> u16temp(temp.size());
 	size = u16temp.size();
 	prt::StringUtils::toUTF16FromUTF8(temp.data(), u16temp.data(), &size, &status);
-	if(size > u16temp.size()) {
+	if (size > u16temp.size()) {
 		u16temp.resize(size);
 		prt::StringUtils::toUTF16FromUTF8(temp.data(), u16temp.data(), &size, &status);
 	}

--- a/src/palladio/Utils.h
+++ b/src/palladio/Utils.h
@@ -18,13 +18,13 @@
 
 #include "PalladioMain.h"
 
-#include "prt/Object.h"
 #include "prt/AttributeMap.h"
-#include "prt/ResolveMap.h"
-#include "prt/InitialShape.h"
-#include "prt/RuleFileInfo.h"
 #include "prt/EncoderInfo.h"
+#include "prt/InitialShape.h"
+#include "prt/Object.h"
 #include "prt/OcclusionSet.h"
+#include "prt/ResolveMap.h"
+#include "prt/RuleFileInfo.h"
 
 #include "GA/GA_Primitive.h"
 
@@ -32,36 +32,41 @@
 #include <string>
 #include <vector>
 
-
-namespace PLD_BOOST_NS { namespace filesystem { class path; } }
+namespace PLD_BOOST_NS {
+namespace filesystem {
+class path;
+}
+} // namespace PLD_BOOST_NS
 
 struct PRTDestroyer {
 	void operator()(prt::Object const* p) {
-		if (p) p->destroy();
+		if (p)
+			p->destroy();
 	}
 };
 
-using PrimitiveNOPtrVector      = std::vector<const GA_Primitive*>;
+using PrimitiveNOPtrVector = std::vector<const GA_Primitive*>;
 
-using ObjectUPtr                = std::unique_ptr<const prt::Object, PRTDestroyer>;
-using InitialShapeNOPtrVector   = std::vector<const prt::InitialShape*>;
-using AttributeMapNOPtrVector   = std::vector<const prt::AttributeMap*>;
-using CacheObjectUPtr           = std::unique_ptr<prt::CacheObject, PRTDestroyer>;
-using AttributeMapUPtr          = std::unique_ptr<const prt::AttributeMap, PRTDestroyer>;
-using AttributeMapVector        = std::vector<AttributeMapUPtr>;
-using AttributeMapBuilderUPtr   = std::unique_ptr<prt::AttributeMapBuilder, PRTDestroyer>;
+using ObjectUPtr = std::unique_ptr<const prt::Object, PRTDestroyer>;
+using InitialShapeNOPtrVector = std::vector<const prt::InitialShape*>;
+using AttributeMapNOPtrVector = std::vector<const prt::AttributeMap*>;
+using CacheObjectUPtr = std::unique_ptr<prt::CacheObject, PRTDestroyer>;
+using AttributeMapUPtr = std::unique_ptr<const prt::AttributeMap, PRTDestroyer>;
+using AttributeMapVector = std::vector<AttributeMapUPtr>;
+using AttributeMapBuilderUPtr = std::unique_ptr<prt::AttributeMapBuilder, PRTDestroyer>;
 using AttributeMapBuilderVector = std::vector<AttributeMapBuilderUPtr>;
-using InitialShapeBuilderUPtr   = std::unique_ptr<prt::InitialShapeBuilder, PRTDestroyer>;
+using InitialShapeBuilderUPtr = std::unique_ptr<prt::InitialShapeBuilder, PRTDestroyer>;
 using InitialShapeBuilderVector = std::vector<InitialShapeBuilderUPtr>;
-using ResolveMapSPtr            = std::shared_ptr<const prt::ResolveMap>;
-using ResolveMapUPtr            = std::unique_ptr<const prt::ResolveMap, PRTDestroyer>;
-using ResolveMapBuilderUPtr     = std::unique_ptr<prt::ResolveMapBuilder, PRTDestroyer>;
-using RuleFileInfoUPtr          = std::unique_ptr<const prt::RuleFileInfo, PRTDestroyer>;
-using EncoderInfoUPtr           = std::unique_ptr<const prt::EncoderInfo, PRTDestroyer>;
-using OcclusionSetUPtr          = std::unique_ptr<prt::OcclusionSet, PRTDestroyer>;
+using ResolveMapSPtr = std::shared_ptr<const prt::ResolveMap>;
+using ResolveMapUPtr = std::unique_ptr<const prt::ResolveMap, PRTDestroyer>;
+using ResolveMapBuilderUPtr = std::unique_ptr<prt::ResolveMapBuilder, PRTDestroyer>;
+using RuleFileInfoUPtr = std::unique_ptr<const prt::RuleFileInfo, PRTDestroyer>;
+using EncoderInfoUPtr = std::unique_ptr<const prt::EncoderInfo, PRTDestroyer>;
+using OcclusionSetUPtr = std::unique_ptr<prt::OcclusionSet, PRTDestroyer>;
 
-PLD_TEST_EXPORTS_API void getCGBs(const ResolveMapSPtr& rm, std::vector<std::pair<std::wstring,std::wstring>>& cgbs);
-PLD_TEST_EXPORTS_API const prt::AttributeMap* createValidatedOptions(const wchar_t* encID, const prt::AttributeMap* unvalidatedOptions);
+PLD_TEST_EXPORTS_API void getCGBs(const ResolveMapSPtr& rm, std::vector<std::pair<std::wstring, std::wstring>>& cgbs);
+PLD_TEST_EXPORTS_API const prt::AttributeMap* createValidatedOptions(const wchar_t* encID,
+                                                                     const prt::AttributeMap* unvalidatedOptions);
 PLD_TEST_EXPORTS_API std::string objectToXML(prt::Object const* obj);
 
 void getLibraryPath(PLD_BOOST_NS::filesystem::path& path, const void* func);
@@ -86,7 +91,7 @@ inline void replace_all_not_of(std::wstring& s, const std::wstring& allowedChars
 }
 
 inline bool startsWithAnyOf(const std::string& s, const std::vector<std::string>& sv) {
-	for (const auto& v: sv) {
+	for (const auto& v : sv) {
 		if (s.find(v) == 0)
 			return true;
 	}

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -13,7 +13,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 		-DTEST_DATA_PATH="${CMAKE_CURRENT_SOURCE_DIR}/data")
 
 if(PLD_LINUX)
-	target_compile_options(${PROJECT_NAME} PRIVATE -std=c++11)
+	target_compile_options(${PROJECT_NAME} PRIVATE -std=c++14)
 endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE
@@ -30,6 +30,6 @@ pld_add_dependency_houdini(${PROJECT_NAME})
 # copy libraries next to test excutable so they can be found
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
 	COMMAND ${CMAKE_COMMAND} ARGS -E make_directory ${CMAKE_BINARY_DIR}/bin
-	COMMAND ${CMAKE_COMMAND} ARGS -E copy ${PRT_LIBRARIES} ${CMAKE_BINARY_DIR}/bin
+	COMMAND ${CMAKE_COMMAND} ARGS -E copy ${PLD_PRT_LIBRARIES} ${CMAKE_BINARY_DIR}/bin
 	COMMAND ${CMAKE_COMMAND} ARGS -E make_directory ${CMAKE_BINARY_DIR}/lib
-	COMMAND ${CMAKE_COMMAND} ARGS -E copy ${PRT_EXT_LIBRARIES} ${CMAKE_BINARY_DIR}/lib)
+	COMMAND ${CMAKE_COMMAND} ARGS -E copy ${PLD_PRT_EXT_LIBRARIES} ${CMAKE_BINARY_DIR}/lib)

--- a/src/test/TestCallbacks.h
+++ b/src/test/TestCallbacks.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include "../palladio/Utils.h"
 #include "../codec/encoder/HoudiniCallbacks.h"
+#include "../palladio/Utils.h"
 
 #include "prt/API.h"
 #include "prt/AttributeMap.h"
@@ -29,7 +29,6 @@
 
 #include <vector>
 #include <string>
-
 
 struct CallbackResult {
 	std::wstring name;
@@ -44,7 +43,7 @@ struct CallbackResult {
 	std::vector<AttributeMapUPtr> materials;
 	std::map<int32_t, AttributeMapUPtr> attrsPerShapeID;
 
-	explicit CallbackResult(size_t uvSets) : uvs(uvSets), uvCounts(uvSets), uvIndices(uvSets) { }
+	explicit CallbackResult(size_t uvSets) : uvs(uvSets), uvCounts(uvSets), uvIndices(uvSets) {}
 };
 
 class TestCallbacks : public HoudiniCallbacks {
@@ -52,43 +51,35 @@ public:
 	std::vector<CallbackResult> results;
 	std::map<int32_t, AttributeMapBuilderUPtr> attrs;
 
-	void add(const wchar_t* name,
-			 const double* vtx, size_t vtxSize,
-			 const double* nrm, size_t nrmSize,
-			 const uint32_t* counts, size_t countsSize,
-			 const uint32_t* indices, size_t indicesSize,
-			 double const* const* uvs, size_t const* uvsSizes,
-			 uint32_t const* const* uvCounts, size_t const* uvCountsSizes,
-			 uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,
-			 uint32_t uvSets,
-			 const uint32_t* faceRanges, size_t faceRangesSize,
-			 const prt::AttributeMap** materials,
-			 const prt::AttributeMap** reports,
-			 const int32_t* shapeIDs
-	) override {
+	void add(const wchar_t* name, const double* vtx, size_t vtxSize, const double* nrm, size_t nrmSize,
+	         const uint32_t* counts, size_t countsSize, const uint32_t* indices, size_t indicesSize,
+	         double const* const* uvs, size_t const* uvsSizes, uint32_t const* const* uvCounts,
+	         size_t const* uvCountsSizes, uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,
+	         uint32_t uvSets, const uint32_t* faceRanges, size_t faceRangesSize, const prt::AttributeMap** materials,
+	         const prt::AttributeMap** reports, const int32_t* shapeIDs) override {
 		results.emplace_back(CallbackResult(uvSets));
 		auto& cr = results.back();
 
 		cr.name = name;
-		cr.vtx.assign(vtx, vtx+vtxSize);
-		cr.nrm.assign(nrm, nrm+nrmSize);
-		cr.cnts.assign(counts, counts+countsSize);
-		cr.idx.assign(indices, indices+indicesSize);
+		cr.vtx.assign(vtx, vtx + vtxSize);
+		cr.nrm.assign(nrm, nrm + nrmSize);
+		cr.cnts.assign(counts, counts + countsSize);
+		cr.idx.assign(indices, indices + indicesSize);
 
 		for (size_t i = 0; i < uvSets; i++) {
-			cr.uvs[i].assign(uvs[i], uvs[i]+uvsSizes[i]);
-			cr.uvCounts[i].assign(uvCounts[i], uvCounts[i]+uvCountsSizes[i]);
-			cr.uvIndices[i].assign(uvIndices[i], uvIndices[i]+uvIndicesSizes[i]);
+			cr.uvs[i].assign(uvs[i], uvs[i] + uvsSizes[i]);
+			cr.uvCounts[i].assign(uvCounts[i], uvCounts[i] + uvCountsSizes[i]);
+			cr.uvIndices[i].assign(uvIndices[i], uvIndices[i] + uvIndicesSizes[i]);
 		}
 
-		cr.faceRanges.assign(faceRanges, faceRanges+faceRangesSize);
+		cr.faceRanges.assign(faceRanges, faceRanges + faceRangesSize);
 
-		for (size_t mi = 0; mi < faceRangesSize-1; mi++) {
+		for (size_t mi = 0; mi < faceRangesSize - 1; mi++) {
 			AttributeMapBuilderUPtr amb(prt::AttributeMapBuilder::createFromAttributeMap(materials[mi]));
 			cr.materials.emplace_back(amb->createAttributeMap());
 		}
 
-		for (size_t si = 0; si < faceRangesSize-1; si++) {
+		for (size_t si = 0; si < faceRangesSize - 1; si++) {
 			const int32_t sid = shapeIDs[si];
 			cr.attrsPerShapeID.emplace(sid, AttributeMapUPtr(attrs.at(sid)->createAttributeMap()));
 		}
@@ -99,11 +90,13 @@ public:
 		return prt::STATUS_OK;
 	}
 
-	prt::Status assetError(size_t isIndex, prt::CGAErrorLevel level, const wchar_t* key, const wchar_t* uri, const wchar_t* message) override {
+	prt::Status assetError(size_t isIndex, prt::CGAErrorLevel level, const wchar_t* key, const wchar_t* uri,
+	                       const wchar_t* message) override {
 		return prt::STATUS_OK;
 	}
 
-	prt::Status cgaError(size_t isIndex, int32_t shapeID, prt::CGAErrorLevel level, int32_t methodId, int32_t pc, const wchar_t* message) override {
+	prt::Status cgaError(size_t isIndex, int32_t shapeID, prt::CGAErrorLevel level, int32_t methodId, int32_t pc,
+	                     const wchar_t* message) override {
 		return prt::STATUS_OK;
 	}
 

--- a/src/test/TestCallbacks.h
+++ b/src/test/TestCallbacks.h
@@ -22,8 +22,10 @@
 #include "prt/API.h"
 #include "prt/AttributeMap.h"
 
+// clang-format off
 #include "../palladio/BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/variant.hpp)
+// clang-format on
 
 #include <vector>
 #include <string>

--- a/src/test/TestCallbacks.h
+++ b/src/test/TestCallbacks.h
@@ -117,6 +117,34 @@ public:
 		return prt::STATUS_OK;
 	}
 
+#if (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 1)
+	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr, size_t size,
+	                          size_t nRows) override {
+		return prt::STATUS_OK;
+	}
+	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr, size_t size,
+	                           size_t nRows) override {
+		return prt::STATUS_OK;
+	}
+	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr,
+	                            size_t size, size_t nRows) override {
+		return prt::STATUS_OK;
+	}
+#elif (PRT_VERSION_MAJOR > 1 && PRT_VERSION_MINOR > 0)
+	prt::Status attrBoolArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const bool* ptr,
+	                          size_t size) override {
+		return prt::STATUS_OK;
+	}
+	prt::Status attrFloatArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const double* ptr,
+	                           size_t size) override {
+		return prt::STATUS_OK;
+	}
+	prt::Status attrStringArray(size_t isIndex, int32_t shapeID, const wchar_t* key, const wchar_t* const* ptr,
+	                            size_t size) override {
+		return prt::STATUS_OK;
+	}
+#endif
+
 	prt::Status attrBool(size_t isIndex, int32_t shapeID, const wchar_t* key, bool value) override {
 		auto it = attrs.emplace(shapeID, AttributeMapBuilderUPtr(prt::AttributeMapBuilder::create()));
 		it.first->second->setBool(key, value);

--- a/src/test/TestCallbacks.h
+++ b/src/test/TestCallbacks.h
@@ -81,7 +81,8 @@ public:
 
 		for (size_t si = 0; si < faceRangesSize - 1; si++) {
 			const int32_t sid = shapeIDs[si];
-			cr.attrsPerShapeID.emplace(sid, AttributeMapUPtr(attrs.at(sid)->createAttributeMap()));
+			if (attrs.count(sid) > 0)
+				cr.attrsPerShapeID.emplace(sid, AttributeMapUPtr(attrs.at(sid)->createAttributeMap()));
 		}
 		attrs.clear();
 	}

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -20,7 +20,6 @@
 
 #include "catch.hpp"
 
-
 namespace {
 
 constexpr const wchar_t* ENCODER_ID_CGA_ERROR = L"com.esri.prt.core.CGAErrorEncoder";
@@ -30,14 +29,9 @@ constexpr const wchar_t* FILE_CGA_PRINT = L"CGAPrint.txt";
 
 } // namespace
 
-
-void generate(TestCallbacks& tc,
-              const PRTContextUPtr& prtCtx,
-              const PLD_BOOST_NS::filesystem::path& rpkPath,
-              const std::wstring& ruleFile,
-              const std::vector<std::wstring>& initialShapeURIs,
-              const std::vector<std::wstring>& startRules)
-{
+void generate(TestCallbacks& tc, const PRTContextUPtr& prtCtx, const PLD_BOOST_NS::filesystem::path& rpkPath,
+              const std::wstring& ruleFile, const std::vector<std::wstring>& initialShapeURIs,
+              const std::vector<std::wstring>& startRules) {
 	REQUIRE(initialShapeURIs.size() == startRules.size());
 
 	ResolveMapSPtr rpkRM = prtCtx->getResolveMap(rpkPath);
@@ -50,11 +44,20 @@ void generate(TestCallbacks& tc,
 	for (size_t ai = 0, numAttrs = ruleFileInfo->getNumAttributes(); ai < numAttrs; ai++) {
 		const auto* a = ruleFileInfo->getAttribute(ai);
 		switch (a->getReturnType()) {
-			case prt::AAT_BOOL: amb->setBool(a->getName(), false); break;
-			case prt::AAT_FLOAT: amb->setFloat(a->getName(), 0.0); break;
-			case prt::AAT_STR: amb->setString(a->getName(), L""); break;
-			case prt::AAT_INT: amb->setInt(a->getName(), 0); break;
-			default: break;
+			case prt::AAT_BOOL:
+				amb->setBool(a->getName(), false);
+				break;
+			case prt::AAT_FLOAT:
+				amb->setFloat(a->getName(), 0.0);
+				break;
+			case prt::AAT_STR:
+				amb->setString(a->getName(), L"");
+				break;
+			case prt::AAT_INT:
+				amb->setInt(a->getName(), 0);
+				break;
+			default:
+				break;
 		}
 	}
 	const AttributeMapUPtr isAttrsProto(amb->createAttributeMapAndReset());
@@ -67,7 +70,8 @@ void generate(TestCallbacks& tc,
 		gd.mInitialShapeBuilders.emplace_back(prt::InitialShapeBuilder::create());
 		auto& isb = gd.mInitialShapeBuilders.back();
 
-		gd.mRuleAttributeBuilders.emplace_back(prt::AttributeMapBuilder::createFromAttributeMap(isAttrsProto.get())); // TODO: use shared_ptr
+		gd.mRuleAttributeBuilders.emplace_back(
+		        prt::AttributeMapBuilder::createFromAttributeMap(isAttrsProto.get())); // TODO: use shared_ptr
 		const auto& rab = gd.mRuleAttributeBuilders.back();
 		gd.mRuleAttributes.emplace_back(rab->createAttributeMap());
 		const auto& am = gd.mRuleAttributes.back();
@@ -75,7 +79,8 @@ void generate(TestCallbacks& tc,
 		const std::wstring sn = L"shape" + std::to_wstring(i);
 
 		REQUIRE(isb->resolveGeometry(uri.c_str()) == prt::STATUS_OK);
-		REQUIRE(isb->setAttributes(ruleFile.c_str(), sr.c_str(), 0, sn.c_str(), am.get(), rpkRM.get()) == prt::STATUS_OK);
+		REQUIRE(isb->setAttributes(ruleFile.c_str(), sr.c_str(), 0, sn.c_str(), am.get(), rpkRM.get()) ==
+		        prt::STATUS_OK);
 
 		prt::Status status = prt::STATUS_UNSPECIFIED_ERROR;
 		const prt::InitialShape* is = isb->createInitialShapeAndReset(&status);
@@ -100,12 +105,12 @@ void generate(TestCallbacks& tc,
 	amb->setInt(L"numberWorkerThreads", prtCtx->mCores);
 	const AttributeMapUPtr generateOptions(amb->createAttributeMapAndReset());
 
-	const std::vector<const wchar_t*> allEncoders = { ENCODER_ID_HOUDINI, ENCODER_ID_CGA_ERROR, ENCODER_ID_CGA_PRINT };
-	const AttributeMapNOPtrVector allEncoderOptions = { houdiniEncOpts.get(), cgaErrorOptions.get(),
-	                                                    cgaPrintOptions.get() };
+	const std::vector<const wchar_t*> allEncoders = {ENCODER_ID_HOUDINI, ENCODER_ID_CGA_ERROR, ENCODER_ID_CGA_PRINT};
+	const AttributeMapNOPtrVector allEncoderOptions = {houdiniEncOpts.get(), cgaErrorOptions.get(),
+	                                                   cgaPrintOptions.get()};
 
-	prt::Status stat = prt::generate(gd.mInitialShapes.data(), gd.mInitialShapes.size(), nullptr,
-	                                 allEncoders.data(), allEncoders.size(), allEncoderOptions.data(), &tc,
-	                                 prtCtx->mPRTCache.get(), nullptr, generateOptions.get());
+	prt::Status stat = prt::generate(gd.mInitialShapes.data(), gd.mInitialShapes.size(), nullptr, allEncoders.data(),
+	                                 allEncoders.size(), allEncoderOptions.data(), &tc, prtCtx->mPRTCache.get(),
+	                                 nullptr, generateOptions.get());
 	REQUIRE(stat == prt::STATUS_OK);
 }

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -29,26 +29,21 @@
 #include <vector>
 #include <string>
 
-
 struct GenerateData { // TODO: could use ShapeData from production code
-	InitialShapeBuilderVector         mInitialShapeBuilders;
-	InitialShapeNOPtrVector           mInitialShapes;
+	InitialShapeBuilderVector mInitialShapeBuilders;
+	InitialShapeNOPtrVector mInitialShapes;
 
-	AttributeMapBuilderVector         mRuleAttributeBuilders;
-	AttributeMapVector                mRuleAttributes;
+	AttributeMapBuilderVector mRuleAttributeBuilders;
+	AttributeMapVector mRuleAttributes;
 
 	~GenerateData() {
-		std::for_each(mInitialShapes.begin(), mInitialShapes.end(), [](const prt::InitialShape* is){
+		std::for_each(mInitialShapes.begin(), mInitialShapes.end(), [](const prt::InitialShape* is) {
 			assert(is != nullptr);
 			is->destroy();
 		});
 	}
 };
 
-
-void generate(TestCallbacks& tc,
-              const PRTContextUPtr& prtCtx,
-              const PLD_BOOST_NS::filesystem::path& rpkPath,
-              const std::wstring& ruleFile,
-              const std::vector<std::wstring>& initialShapeURIs,
+void generate(TestCallbacks& tc, const PRTContextUPtr& prtCtx, const PLD_BOOST_NS::filesystem::path& rpkPath,
+              const std::wstring& ruleFile, const std::vector<std::wstring>& initialShapeURIs,
               const std::vector<std::wstring>& startRules);

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -21,8 +21,10 @@
 #include "../palladio/PRTContext.h"
 #include "../palladio/Utils.h"
 
+// clang-format off
 #include "../palladio/BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/filesystem.hpp)
+// clang-format on
 
 #include <vector>
 #include <string>

--- a/src/test/tests.cpp
+++ b/src/test/tests.cpp
@@ -27,8 +27,10 @@
 #include "prtx/Geometry.h"
 #include "prtx/Mesh.h"
 
+// clang-format off
 #include "../palladio/BoostRedirect.h"
 #include PLD_BOOST_INCLUDE(/filesystem/path.hpp)
+// clang-format on
 
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"


### PR DESCRIPTION
This is a big PR covering multiple topics:
* Update to PRT 2.2 (includes requiring MSVC 14.2 on Windows)
* Adding array attribute support both when creating initial shapes and when re-emitting them onto the generated models.
* Fixing the unit tests.
* Pruning Houdini 17.0 from the CI pipeline.
* Various code cleanups and small improvements.