### PR TITLE
Use https url to avoid need for SSH credentials.

### DIFF
--- a/pipeline.groovy
+++ b/pipeline.groovy
@@ -15,7 +15,7 @@ import com.esri.zrh.jenkins.psl.UploadTrackingPsl
 
 // -- GLOBAL DEFINITIONS
 
-@Field final String REPO         = 'git@github.com:Esri/palladio.git'
+@Field final String REPO         = 'https://github.com/Esri/palladio.git'
 @Field final String SOURCE       = "palladio.git/src"
 @Field final String BUILD_TARGET = 'package'
 


### PR DESCRIPTION
Since this is a public repository and since the build only reads from the repo, it makes sense to avoid the need to manage credentials for the repository and use the https url for cloning.

If at a later point we decide that we need write access to the repo we can switch to using a deploy key.