### PR TITLE
Cknieling/fix attribute reload

### DIFF
--- a/src/palladio/NodeSpareParameter.cpp
+++ b/src/palladio/NodeSpareParameter.cpp
@@ -127,6 +127,49 @@ void addArrayParm(OP_Node* node, const std::wstring& id, const std::wstring& nam
 	addParmsFromTemplateArray(node, myTemplateList, parentFolders);
 }
 
+void addEnumParm(OP_Node* node, const std::wstring& id, const std::wstring& name, const std::wstring& defaultOption,
+                 const std::vector<std::wstring>& mOptions, const char* enumType, const FolderVec& parentFolders,
+                 const std::wstring& description) {
+	const size_t optionCount = mOptions.size();
+
+	std::unique_ptr<PRM_Name[]> optionNames = std::make_unique<PRM_Name[]>(optionCount + 1);
+
+	PRM_Default defaultVal(0);
+	for (int i = 0; i < optionCount; ++i) {
+		UT_StringHolder option(toOSNarrowFromUTF16(mOptions[i]));
+		optionNames[i].setTokenAndLabel(option, option);
+		if (mOptions[i] == defaultOption)
+			defaultVal.setOrdinal(i);
+	}
+	optionNames[optionCount].setAsSentinel();
+
+	PRM_ChoiceList enumMenu((PRM_ChoiceListType)(PRM_CHOICELIST_EXCLUSIVE | PRM_CHOICELIST_REPLACE), optionNames.get());
+
+	UT_StringHolder token(toOSNarrowFromUTF16(id));
+	UT_StringHolder label(toOSNarrowFromUTF16(name));
+
+	std::string helpText(toOSNarrowFromUTF16(description));
+
+	PRM_Name stringParmName(token, label);
+
+	PRM_SpareToken sparetoken(NodeSpareParameter::PRM_ENUM_TYPE_TOKEN, enumType);
+	PRM_SpareData mySpareData(sparetoken);
+
+	PRM_Template templateArr[] = {PRM_Template(PRM_ORD,                      // parm type
+	                                           PRM_Template::PRM_EXPORT_MAX, // number of folders
+	                                           1,
+	                                           &stringParmName,   // name
+	                                           &defaultVal,       // defaults
+	                                           &enumMenu,         // choicelist
+	                                           nullptr,           // rangeptr
+	                                           nullptr,           // callbackfunc
+	                                           &mySpareData,       // spareData
+	                                           1,                 // parmGroup
+	                                           helpText.c_str()), // helptext
+	                              PRM_Template()};
+
+	addParmsFromTemplateArray(node, templateArr, parentFolders);
+}
 } // namespace
 
 namespace NodeSpareParameter {
@@ -199,45 +242,18 @@ void addStringArrayParm(OP_Node* node, const std::wstring& id, const std::wstrin
 	addArrayParm<std::wstring>(node, id, name, defaultVals, parentFolders, annotation, "stringVecParm#", PRM_STRING);
 }
 
-void addEnumParm(OP_Node* node, const std::wstring& id, const std::wstring& name, const std::wstring& defaultOption,
-                 const std::vector<std::wstring>& mOptions, const FolderVec& parentFolders,
-                 const std::wstring& description) {
-	const size_t optionCount = mOptions.size();
+void addStringEnumParm(OP_Node* node, const std::wstring& id, const std::wstring& name,
+                       const std::wstring& defaultOption,
+                       const std::vector<std::wstring>& mOptions, const FolderVec& parentFolders,
+                       const std::wstring& description) {
+	addEnumParm(node, id, name, defaultOption, mOptions, PRM_ENUM_TYPE_STRING, parentFolders, description);
+}
 
-	std::unique_ptr<PRM_Name[]> optionNames = std::make_unique<PRM_Name[]>(optionCount + 1);
-
-	PRM_Default defaultVal(0);
-	for (int i = 0; i < optionCount; ++i) {
-		UT_StringHolder option(toOSNarrowFromUTF16(mOptions[i]));
-		optionNames[i].setTokenAndLabel(option, option);
-		if (mOptions[i] == defaultOption)
-			defaultVal.setOrdinal(i);
-	}
-	optionNames[optionCount].setAsSentinel();
-
-	PRM_ChoiceList enumMenu((PRM_ChoiceListType)(PRM_CHOICELIST_EXCLUSIVE | PRM_CHOICELIST_REPLACE), optionNames.get());
-
-	UT_StringHolder token(toOSNarrowFromUTF16(id));
-	UT_StringHolder label(toOSNarrowFromUTF16(name));
-
-	std::string helpText(toOSNarrowFromUTF16(description));
-
-	PRM_Name stringParmName(token, label);
-
-	PRM_Template templateArr[] = {PRM_Template(PRM_ORD,                      // parm type
-	                                           PRM_Template::PRM_EXPORT_MAX, // number of folders
-	                                           1,
-	                                           &stringParmName,   // name
-	                                           &defaultVal,       // defaults
-	                                           &enumMenu,         // choicelist
-	                                           nullptr,           // rangeptr
-	                                           nullptr,           // callbackfunc
-	                                           nullptr,           // spareData
-	                                           1,                 // parmGroup
-	                                           helpText.c_str()), // helptext
-	                              PRM_Template()};
-
-	addParmsFromTemplateArray(node, templateArr, parentFolders);
+void addFloatEnumParm(OP_Node* node, const std::wstring& id, const std::wstring& name,
+                      const std::wstring& defaultOption,
+                      const std::vector<std::wstring>& mOptions, const FolderVec& parentFolders,
+                      const std::wstring& description) {
+	addEnumParm(node, id, name, defaultOption, mOptions, PRM_ENUM_TYPE_FLOAT, parentFolders, description);
 }
 
 void addFileParm(OP_Node* node, const std::wstring& id, const std::wstring& name, const std::wstring& defaultVal,

--- a/src/palladio/NodeSpareParameter.cpp
+++ b/src/palladio/NodeSpareParameter.cpp
@@ -132,7 +132,7 @@ void addEnumParm(OP_Node* node, const std::wstring& id, const std::wstring& name
                  const std::wstring& description) {
 	const size_t optionCount = mOptions.size();
 
-	std::unique_ptr<PRM_Name[]> optionNames = std::make_unique<PRM_Name[]>(optionCount + 1);
+	auto optionNames = std::make_unique<PRM_Name[]>(optionCount + 1);
 
 	PRM_Default defaultVal(0);
 	for (int i = 0; i < optionCount; ++i) {

--- a/src/palladio/NodeSpareParameter.h
+++ b/src/palladio/NodeSpareParameter.h
@@ -25,6 +25,10 @@ using FolderVec = std::vector<std::wstring>;
 namespace NodeSpareParameter {
 constexpr const char* PRM_SPARE_IS_PERCENT_TOKEN = "palladio::is_percent";
 
+constexpr const char* PRM_ENUM_TYPE_TOKEN = "palladio::enum_type";
+constexpr const char* PRM_ENUM_TYPE_STRING = "string";
+constexpr const char* PRM_ENUM_TYPE_FLOAT = "float";
+
 void clearAllParms(OP_Node* node);
 void addFloatParm(OP_Node* node, const std::wstring& id, const std::wstring& name, double defaultVal,
                   double min = std::numeric_limits<double>::quiet_NaN(),
@@ -45,9 +49,12 @@ void addFloatArrayParm(OP_Node* node, const std::wstring& id, const std::wstring
 void addStringArrayParm(OP_Node* node, const std::wstring& id, const std::wstring& name,
                         const std::vector<std::wstring>& defaultVals, const FolderVec& parentFolders = {},
                         const std::wstring& annotation = {});
-void addEnumParm(OP_Node* node, const std::wstring& id, const std::wstring& name, const std::wstring& defaultIdx,
-                 const std::vector<std::wstring>& mOptions, const FolderVec& parentFolders,
-                 const std::wstring& description = {});
+void addStringEnumParm(OP_Node* node, const std::wstring& id, const std::wstring& name,
+                       const std::wstring& defaultOption, const std::vector<std::wstring>& mOptions,
+                       const FolderVec& parentFolders, const std::wstring& description = {});
+void addFloatEnumParm(OP_Node* node, const std::wstring& id, const std::wstring& name,
+                      const std::wstring& defaultOption, const std::vector<std::wstring>& mOptions,
+                      const FolderVec& parentFolders, const std::wstring& description = {});
 void addFileParm(OP_Node* node, const std::wstring& id, const std::wstring& name, const std::wstring& defaultVal,
                  const std::vector<std::wstring>& extensions, const FolderVec& parentFolders, const std::wstring& description = {});
 void addDirectoryParm(OP_Node* node, const std::wstring& id, const std::wstring& name, const std::wstring& defaultVal,

--- a/src/palladio/RuleAttributes.cpp
+++ b/src/palladio/RuleAttributes.cpp
@@ -22,7 +22,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <filesystem>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -82,10 +81,10 @@ void setGlobalGroupOrder(RuleAttributeVec& ruleAttributes) {
 	}
 }
 
-RuleAttributeSet getRuleAttributes(const std::wstring& ruleFile, const prt::RuleFileInfo* ruleFileInfo) {
+RuleAttributeSet getRuleAttributes(const std::filesystem::path& ruleFile, const prt::RuleFileInfo* ruleFileInfo) {
 	RuleAttributeVec ra;
 
-	std::wstring mainCgaRuleName = std::filesystem::path(ruleFile).stem().wstring();
+	std::wstring mainCgaRuleName = ruleFile.stem().wstring();
 
 	const ImportOrderMap importOrderMap = getImportOrderMap(ruleFileInfo);
 

--- a/src/palladio/RuleAttributes.h
+++ b/src/palladio/RuleAttributes.h
@@ -18,6 +18,7 @@
 
 #include "prt/Annotation.h"
 
+#include <filesystem>
 #include <limits>
 #include <map>
 #include <set>
@@ -72,5 +73,5 @@ using RuleAttributeVec = std::vector<RuleAttribute>;
 using RuleAttributeSet = std::set<RuleAttribute, RuleAttributeCmp>;
 using RuleAttributeMap = std::map<std::wstring, RuleAttribute>;
 
-RuleAttributeSet getRuleAttributes(const std::wstring& ruleFile, const prt::RuleFileInfo* ruleFileInfo);
+RuleAttributeSet getRuleAttributes(const std::filesystem::path& ruleFile, const prt::RuleFileInfo* ruleFileInfo);
 void setGlobalGroupOrder(RuleAttributeVec& ruleAttributes);

--- a/src/palladio/SOPAssign.cpp
+++ b/src/palladio/SOPAssign.cpp
@@ -650,16 +650,20 @@ AnnotationParsing::RangeAnnotation getRange(const AnnotationParsing::TraitParame
 };
 
 bool tryHandleEnum(SOPAssign* node, const std::wstring attrId, const std::wstring attrName, std::wstring defaultValue,
-                   const AnnotationParsing::TraitParameterMap& traitParmMap, const std::wstring& description,
-                   std::vector<std::wstring> parentFolders) {
+                   bool isFloatEnum, const AnnotationParsing::TraitParameterMap& traitParmMap,
+                   const std::wstring& description, std::vector<std::wstring> parentFolders) {
 	const auto& enumIt = traitParmMap.find(AnnotationParsing::AttributeTrait::ENUM);
 	if (enumIt == traitParmMap.end())
 		return false;
 
 	AnnotationParsing::EnumAnnotation enumAnnotation = std::get<AnnotationParsing::EnumAnnotation>(enumIt->second);
 
-	NodeSpareParameter::addEnumParm(node, attrId, attrName, defaultValue, enumAnnotation.mOptions, parentFolders,
-	                                description);
+	if (isFloatEnum)
+		NodeSpareParameter::addFloatEnumParm(node, attrId, attrName, defaultValue, enumAnnotation.mOptions,
+		                                     parentFolders, description);
+	else
+		NodeSpareParameter::addStringEnumParm(node, attrId, attrName, defaultValue, enumAnnotation.mOptions,
+		                                     parentFolders, description);
 	return true;
 }
 
@@ -992,7 +996,7 @@ void SOPAssign::buildUI(GU_Detail* detail, ShapeData& shapeData, const ShapeConv
 			case prt::AnnotationArgumentType::AAT_FLOAT: {
 				const double defaultValue = getDefaultFloat(defaultCGAAttrValue);
 
-				if (tryHandleEnum(this, attrId, attrName, std::to_wstring(defaultValue), traitParmMap, description,
+				if (tryHandleEnum(this, attrId, attrName, std::to_wstring(defaultValue), true, traitParmMap, description,
 				                  parentFolders)) {
 					continue;
 				}
@@ -1008,7 +1012,7 @@ void SOPAssign::buildUI(GU_Detail* detail, ShapeData& shapeData, const ShapeConv
 			case prt::AnnotationArgumentType::AAT_STR: {
 				const std::wstring defaultValue = getDefaultString(defaultCGAAttrValue);
 
-				if (tryHandleEnum(this, attrId, attrName, defaultValue, traitParmMap, description, parentFolders)) {
+				if (tryHandleEnum(this, attrId, attrName, defaultValue, false, traitParmMap, description, parentFolders)) {
 					continue;
 				}
 

--- a/src/palladio/SOPAssign.cpp
+++ b/src/palladio/SOPAssign.cpp
@@ -88,11 +88,11 @@ RuleFileInfoUPtr getRuleFileInfoFromShapeData(const GU_Detail* detail, ShapeData
 	return getRuleFileInfo(ma, resolveMap, prtCtx->mPRTCache.get());
 }
 
-enum class SpareParmType { FLT, BOOL, STR, FLT_ARRAY, BOOL_ARRAY, STR_ARRAY, FLT_ENUM, STR_ENUM, COLOR };
-using SpareParmTypeMap = std::map<std::wstring, SpareParmType>;
+enum class CGAAttributeType { FLT, BOOL, STR, FLT_ARRAY, BOOL_ARRAY, STR_ARRAY, FLT_ENUM, STR_ENUM, COLOR };
+using CGAAttributeTypeMap = std::map<std::wstring, CGAAttributeType>;
 
-SpareParmTypeMap getSpareParms(SOPAssign* node) {
-	SpareParmTypeMap spareParmVec;
+CGAAttributeTypeMap getCGAAttributeTypes(SOPAssign* node) {
+	CGAAttributeTypeMap spareParmVec;
 
 	PRM_ParmList* parmList = node->getParmList();
 	if (parmList == nullptr)
@@ -122,13 +122,13 @@ SpareParmTypeMap getSpareParms(SOPAssign* node) {
 							continue;
 
 						if (!strcmp(enumType, NodeSpareParameter::PRM_ENUM_TYPE_FLOAT))
-							spareParmVec[ruleAttrName] = SpareParmType::FLT_ENUM;
+							spareParmVec[ruleAttrName] = CGAAttributeType::FLT_ENUM;
 						else if (!strcmp(enumType, NodeSpareParameter::PRM_ENUM_TYPE_STRING))
-							spareParmVec[ruleAttrName] = SpareParmType::STR_ENUM;
+							spareParmVec[ruleAttrName] = CGAAttributeType::STR_ENUM;
 						break;
 					}
 					case PRM_Type::PRM_ORD_TOGGLE: {
-						spareParmVec[ruleAttrName] = SpareParmType::BOOL;
+						spareParmVec[ruleAttrName] = CGAAttributeType::BOOL;
 						break;
 					}
 					default:
@@ -146,13 +146,13 @@ SpareParmTypeMap getSpareParms(SOPAssign* node) {
 					const PRM_Type multiType = templatePtr->getType();
 					switch (multiType.getBasicType()) {
 						case PRM_Type::PRM_BasicType::PRM_BASIC_ORDINAL:
-							spareParmVec[ruleAttrName] = SpareParmType::BOOL_ARRAY;
+							spareParmVec[ruleAttrName] = CGAAttributeType::BOOL_ARRAY;
 							break;
 						case PRM_Type::PRM_BasicType::PRM_BASIC_FLOAT:
-							spareParmVec[ruleAttrName] = SpareParmType::FLT_ARRAY;
+							spareParmVec[ruleAttrName] = CGAAttributeType::FLT_ARRAY;
 							break;
 						case PRM_Type::PRM_BasicType::PRM_BASIC_STRING:
-							spareParmVec[ruleAttrName] = SpareParmType::STR_ARRAY;
+							spareParmVec[ruleAttrName] = CGAAttributeType::STR_ARRAY;
 							break;
 						default:
 							break;
@@ -161,11 +161,11 @@ SpareParmTypeMap getSpareParms(SOPAssign* node) {
 				else {
 					switch (currParmType.getFloatType()) {
 						case PRM_Type::PRM_FLOAT_RGBA: {
-							spareParmVec[ruleAttrName] = SpareParmType::COLOR;
+							spareParmVec[ruleAttrName] = CGAAttributeType::COLOR;
 							break;
 						}
 						default: {
-							spareParmVec[ruleAttrName] = SpareParmType::FLT;
+							spareParmVec[ruleAttrName] = CGAAttributeType::FLT;
 							break;
 						}
 					}
@@ -173,7 +173,7 @@ SpareParmTypeMap getSpareParms(SOPAssign* node) {
 				break;
 			}
 			case PRM_Type::PRM_BasicType::PRM_BASIC_STRING: {
-				spareParmVec[ruleAttrName] = SpareParmType::STR;
+				spareParmVec[ruleAttrName] = CGAAttributeType::STR;
 				break;
 			}
 			default: {
@@ -186,43 +186,43 @@ SpareParmTypeMap getSpareParms(SOPAssign* node) {
 }
 
 bool compareAttributeTypes(SOPAssign* node, const RuleAttributeSet& ruleAttributes) {
-	SpareParmTypeMap spareParmTypeMap = getSpareParms(node);
+	CGAAttributeTypeMap CGAAttributeTypeMap = getCGAAttributeTypes(node);
 
-	if (spareParmTypeMap.size() < ruleAttributes.size())
+	if (CGAAttributeTypeMap.size() < ruleAttributes.size())
 		return false;
 
 	for (const auto& ra : ruleAttributes) {
 
-		const auto& spareParmTypeIt = spareParmTypeMap.find(ra.fqName);
-		if (spareParmTypeIt == spareParmTypeMap.end())
+		const auto& CGAAttributeTypeIt = CGAAttributeTypeMap.find(ra.fqName);
+		if (CGAAttributeTypeIt == CGAAttributeTypeMap.end())
 			return false;
 
 		// check if data types match
-		switch (spareParmTypeIt->second) {
-			case SpareParmType::BOOL:
+		switch (CGAAttributeTypeIt->second) {
+			case CGAAttributeType::BOOL:
 				if (ra.mType != prt::AnnotationArgumentType::AAT_BOOL)
 					return false;
 				break;
-			case SpareParmType::FLT:
-			case SpareParmType::FLT_ENUM:
+			case CGAAttributeType::FLT:
+			case CGAAttributeType::FLT_ENUM:
 				if (ra.mType != prt::AnnotationArgumentType::AAT_FLOAT)
 					return false;
 				break;
-			case SpareParmType::STR:
-			case SpareParmType::STR_ENUM:
-			case SpareParmType::COLOR:
+			case CGAAttributeType::STR:
+			case CGAAttributeType::STR_ENUM:
+			case CGAAttributeType::COLOR:
 				if (ra.mType != prt::AnnotationArgumentType::AAT_STR)
 					return false;
 				break;
-			case SpareParmType::FLT_ARRAY:
+			case CGAAttributeType::FLT_ARRAY:
 				if (ra.mType != prt::AnnotationArgumentType::AAT_FLOAT_ARRAY)
 					return false;
 				break;
-			case SpareParmType::BOOL_ARRAY:
+			case CGAAttributeType::BOOL_ARRAY:
 				if (ra.mType != prt::AnnotationArgumentType::AAT_BOOL_ARRAY)
 					return false;
 				break;
-			case SpareParmType::STR_ARRAY:
+			case CGAAttributeType::STR_ARRAY:
 				if (ra.mType != prt::AnnotationArgumentType::AAT_STR_ARRAY)
 					return false;
 				break;

--- a/src/palladio/SOPAssign.cpp
+++ b/src/palladio/SOPAssign.cpp
@@ -798,7 +798,7 @@ AnnotationParsing::RangeAnnotation getRange(const AnnotationParsing::TraitParame
 };
 
 bool tryHandleEnum(SOPAssign* node, const std::wstring attrId, const std::wstring attrName, std::wstring defaultValue,
-                   bool isFloatEnum, const AnnotationParsing::TraitParameterMap& traitParmMap,
+                   prt::AnnotationArgumentType enumType, const AnnotationParsing::TraitParameterMap& traitParmMap,
                    const std::wstring& description, std::vector<std::wstring> parentFolders) {
 	const auto& enumIt = traitParmMap.find(AnnotationParsing::AttributeTrait::ENUM);
 	if (enumIt == traitParmMap.end())
@@ -806,12 +806,17 @@ bool tryHandleEnum(SOPAssign* node, const std::wstring attrId, const std::wstrin
 
 	AnnotationParsing::EnumAnnotation enumAnnotation = std::get<AnnotationParsing::EnumAnnotation>(enumIt->second);
 
-	if (isFloatEnum)
-		NodeSpareParameter::addFloatEnumParm(node, attrId, attrName, defaultValue, enumAnnotation.mOptions,
-		                                     parentFolders, description);
-	else
-		NodeSpareParameter::addStringEnumParm(node, attrId, attrName, defaultValue, enumAnnotation.mOptions,
-		                                     parentFolders, description);
+	switch (enumType) {
+		case prt::AnnotationArgumentType::AAT_FLOAT:
+			NodeSpareParameter::addFloatEnumParm(node, attrId, attrName, defaultValue, enumAnnotation.mOptions,
+			                                     parentFolders, description);
+		case prt::AnnotationArgumentType::AAT_STR:
+			NodeSpareParameter::addStringEnumParm(node, attrId, attrName, defaultValue, enumAnnotation.mOptions,
+			                                      parentFolders, description);
+		default:
+			return false;
+	}
+
 	return true;
 }
 
@@ -1126,8 +1131,8 @@ void SOPAssign::buildUI(const RuleAttributeSet& ruleAttributes, const RuleFileIn
 			case prt::AnnotationArgumentType::AAT_FLOAT: {
 				const double defaultValue = getDefaultFloat(defaultCGAAttrValue);
 
-				if (tryHandleEnum(this, attrId, attrName, std::to_wstring(defaultValue), true, traitParmMap, description,
-				                  parentFolders)) {
+				if (tryHandleEnum(this, attrId, attrName, std::to_wstring(defaultValue), ra.mType, traitParmMap,
+				                  description, parentFolders)) {
 					continue;
 				}
 
@@ -1142,7 +1147,8 @@ void SOPAssign::buildUI(const RuleAttributeSet& ruleAttributes, const RuleFileIn
 			case prt::AnnotationArgumentType::AAT_STR: {
 				const std::wstring defaultValue = getDefaultString(defaultCGAAttrValue);
 
-				if (tryHandleEnum(this, attrId, attrName, defaultValue, false, traitParmMap, description, parentFolders)) {
+				if (tryHandleEnum(this, attrId, attrName, defaultValue, ra.mType, traitParmMap, description,
+				                  parentFolders)) {
 					continue;
 				}
 

--- a/src/palladio/SOPAssign.cpp
+++ b/src/palladio/SOPAssign.cpp
@@ -986,11 +986,6 @@ void SOPAssign::buildUI(GU_Detail* detail, ShapeData& shapeData, const ShapeConv
 			case prt::AnnotationArgumentType::AAT_BOOL: {
 				const bool defaultValue = getDefaultBool(defaultCGAAttrValue);
 
-				if (tryHandleEnum(this, attrId, attrName, std::to_wstring(defaultValue), traitParmMap, description,
-				                  parentFolders)) {
-					continue;
-				}
-
 				NodeSpareParameter::addBoolParm(this, attrId, attrName, defaultValue, parentFolders, description);
 				break;
 			}

--- a/src/palladio/SOPAssign.cpp
+++ b/src/palladio/SOPAssign.cpp
@@ -68,8 +68,8 @@ RuleFileInfoUPtr getRuleFileInfo(const MainAttributes& ma, const ResolveMapSPtr&
 }
 
 RuleFileInfoUPtr getRuleFileInfoFromShapeData(const GU_Detail* detail, ShapeData& shapeData, size_t initialShapeIdx,
-                                                   const ShapeConverterUPtr& shapeConverter,
-                                                   const PRTContextUPtr& prtCtx, std::string& errors) {
+                                              const ShapeConverterUPtr& shapeConverter, const PRTContextUPtr& prtCtx,
+                                              std::string& errors) {
 	const auto& pv = shapeData.getPrimitiveMapping(initialShapeIdx);
 	const auto& firstPrimitive = pv.front();
 
@@ -683,8 +683,7 @@ bool evaluateDefaultRuleAttributes(SOPAssign* node, const GU_Detail* detail, Sha
 			return false;
 		}
 
-		ruleFileInfos[isIdx] =
-		        getRuleFileInfoFromShapeData(detail, shapeData, isIdx, shapeConverter, prtCtx, errors);
+		ruleFileInfos[isIdx] = getRuleFileInfoFromShapeData(detail, shapeData, isIdx, shapeConverter, prtCtx, errors);
 
 		const std::wstring shapeName = L"shape_" + std::to_wstring(isIdx);
 		if (DBG)
@@ -735,7 +734,8 @@ bool evaluateDefaultRuleAttributes(SOPAssign* node, const GU_Detail* detail, Sha
 	return true;
 }
 
-SOPAssign::CGAAttributeValueType getDefaultCGAAttrValue(const SOPAssign::CGAAttributeValueMap& cgaAttrMap, const std::wstring& key) {
+SOPAssign::CGAAttributeValueType getDefaultCGAAttrValue(const SOPAssign::CGAAttributeValueMap& cgaAttrMap,
+                                                        const std::wstring& key) {
 	const auto& defaultValIt = cgaAttrMap.find(key);
 	if (defaultValIt != cgaAttrMap.end())
 		return defaultValIt->second;
@@ -777,8 +777,6 @@ std::vector<std::wstring> getDefaultStringVec(const SOPAssign::CGAAttributeValue
 		return std::get<std::vector<std::wstring>>(defaultValue);
 	return {};
 }
-
-
 
 std::wstring getDescription(const AnnotationParsing::TraitParameterMap& traitParmMap) {
 	const auto& descriptionIt = traitParmMap.find(AnnotationParsing::AttributeTrait::DESCRIPTION);
@@ -1052,7 +1050,7 @@ void SOPAssign::updatePrimitiveAttributes(GU_Detail* detail) {
 								const PRM_SpareData* spareData = parm.getSparePtr();
 								if (spareData != nullptr) {
 									const char* isPercent =
-										spareData->getValue(NodeSpareParameter::PRM_SPARE_IS_PERCENT_TOKEN);
+									        spareData->getValue(NodeSpareParameter::PRM_SPARE_IS_PERCENT_TOKEN);
 									if ((isPercent != nullptr) && (strcmp(isPercent, "true") == 0))
 										floatValue /= PERCENT_FACTOR;
 								}
@@ -1175,13 +1173,13 @@ void SOPAssign::buildUI(const RuleAttributeSet& ruleAttributes, const RuleFileIn
 			case prt::AnnotationArgumentType::AAT_FLOAT_ARRAY: {
 				const std::vector<double> defaultValues = getDefaultFloatVec(defaultCGAAttrValue);
 				NodeSpareParameter::addFloatArrayParm(this, attrId, attrName, defaultValues, parentFolders,
-					description);
+				                                      description);
 				break;
 			}
 			case prt::AnnotationArgumentType::AAT_STR_ARRAY: {
 				const std::vector<std::wstring> defaultValues = getDefaultStringVec(defaultCGAAttrValue);
 				NodeSpareParameter::addStringArrayParm(this, attrId, attrName, defaultValues, parentFolders,
-					description);
+				                                       description);
 				break;
 			}
 			default:

--- a/src/palladio/SOPAssign.h
+++ b/src/palladio/SOPAssign.h
@@ -18,6 +18,7 @@
 
 #include "PRTContext.h"
 #include "ShapeConverter.h"
+#include "RuleAttributes.h"
 
 #include "SOP/SOP_Node.h"
 
@@ -40,8 +41,7 @@ public:
 
 	void updateDefaultCGAAttributes(const ShapeData& shapeData);
 	void updatePrimitiveAttributes(GU_Detail* detail);
-	void buildUI(GU_Detail* detail, ShapeData& shapeData, const ShapeConverterUPtr& shapeConverter,
-	                        const PRTContextUPtr& prtCtx, std::string& errors);
+	void buildUI(const RuleAttributeSet& ruleAttributes, const RuleFileInfoUPtr& ruleFileInfo);
 	void opChanged(OP_EventType reason, void* data = nullptr) override;
 
 protected:

--- a/src/palladio/SOPAssign.h
+++ b/src/palladio/SOPAssign.h
@@ -43,7 +43,6 @@ public:
 	void buildUI(GU_Detail* detail, ShapeData& shapeData, const ShapeConverterUPtr& shapeConverter,
 	                        const PRTContextUPtr& prtCtx, std::string& errors);
 	void opChanged(OP_EventType reason, void* data = nullptr) override;
-	bool load(UT_IStream& is, const char* extension, const char* path) override;
 
 protected:
 	OP_ERROR cookMySop(OP_Context& context) override;
@@ -51,7 +50,6 @@ protected:
 private:
 	const PRTContextUPtr& mPRTCtx;
 	ShapeConverterUPtr mShapeConverter;
-	bool mWasJustLoaded = false;
 
 public:
 	using CGAAttributeValueType = std::variant<std::monostate, std::wstring, double, bool, std::vector<std::wstring>, std::vector<double>, std::vector<bool>>;


### PR DESCRIPTION
- Compare current UI to attribute information in ruleFileInfo to decide whether UI should be updated.
- Removed file just loaded check.
- always display checkmarks as booleans (since boolean enums don't really make much sense)