### PR TITLE
Cknieling/separate vertex attr indices

### DIFF
--- a/src/codec/encoder/HoudiniCallbacks.h
+++ b/src/codec/encoder/HoudiniCallbacks.h
@@ -35,8 +35,10 @@ public:
 	 * @param nrmSize length of vertex normal array
 	 * @param counts polygon count array
 	 * @param countsSize length of polygon count array
-	 * @param indices vertex attribute index array (grouped by counts)
-	 * @param indicesSize vertex attribute index array
+	 * @param vertexIndices vertex attribute index array (grouped by counts)
+	 * @param vertexIndicesSize vertex attribute index array
+	 * @param normalIndices vertex normal attribute index array (grouped by counts)
+	 * @param normalIndicesSize vertex normal attribute index array
 	 * @param uvs array of texture coordinate arrays (same indexing as vertices per uv set)
 	 * @param uvsSizes lengths of uv arrays per uv set
 	 * @param uvCounts uv index count per face per uv set (values are either 0 or same as vertex count for each face)
@@ -51,7 +53,8 @@ public:
 	 * @param shapeIDs shape ids per face, contains faceRangesSize-1 values
 	 */
 	virtual void add(const wchar_t* name, const double* vtx, size_t vtxSize, const double* nrm, size_t nrmSize,
-	                 const uint32_t* counts, size_t countsSize, const uint32_t* indices, size_t indicesSize,
+	                 const uint32_t* counts, size_t countsSize, const uint32_t* vertexIndices, size_t vertexIndicesSize,
+	                 const uint32_t* normalIndices, size_t normalIndicesSize,
 
 	                 double const* const* uvs, size_t const* uvsSizes, uint32_t const* const* uvCounts,
 	                 size_t const* uvCountsSizes, uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,

--- a/src/codec/encoder/HoudiniEncoder.cpp
+++ b/src/codec/encoder/HoudiniEncoder.cpp
@@ -423,6 +423,7 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries,
 
 	// PASS 2: copy
 	uint32_t vertexIndexBase = 0;
+	uint32_t normalIndexBase = 0;
 	std::vector<uint32_t> uvIndexBases(maxNumUVSets, 0u);
 	for (const auto& geo : geometries) {
 		const prtx::MeshPtrVector& meshes = geo->getMeshes();
@@ -480,14 +481,20 @@ SerializedGeometry serializeGeometry(const prtx::GeometryPtrVector& geometries,
 
 			// append counts and indices for vertices and vertex normals
 			for (uint32_t fi = 0, faceCount = mesh->getFaceCount(); fi < faceCount; ++fi) {
-				const uint32_t* vtxIdx = mesh->getFaceVertexIndices(fi);
 				const uint32_t vtxCnt = mesh->getFaceVertexCount(fi);
+
+				const uint32_t* vtxIdx = mesh->getFaceVertexIndices(fi);
+				const uint32_t* nrmIdx = mesh->getFaceVertexNormalIndices(fi);
 				sg.counts.push_back(vtxCnt);
-				for (uint32_t vi = 0; vi < vtxCnt; vi++)
-					sg.indices.push_back(vertexIndexBase + vtxIdx[vtxCnt - vi - 1]); // reverse winding
+				for (uint32_t vi = 0; vi < vtxCnt; vi++) {
+					uint32_t viReversed = vtxCnt - vi - 1; // reverse winding
+					sg.vertexIndices.push_back(vertexIndexBase + vtxIdx[viReversed]);
+					sg.normalIndices.push_back(normalIndexBase + nrmIdx[viReversed]);		
+				}
 			}
 
 			vertexIndexBase += (uint32_t)verts.size() / 3u;
+			normalIndexBase += (uint32_t)norms.size() / 3u;
 		} // for all meshes
 	}     // for all geometries
 
@@ -623,7 +630,8 @@ void HoudiniEncoder::convertGeometry(const prtx::InitialShape& initialShape,
 	assert(sg.uvs.size() == puvCounts.second.size());
 
 	cb->add(initialShape.getName(), sg.coords.data(), sg.coords.size(), sg.normals.data(), sg.normals.size(),
-	        sg.counts.data(), sg.counts.size(), sg.indices.data(), sg.indices.size(),
+	        sg.counts.data(), sg.counts.size(), sg.vertexIndices.data(), sg.vertexIndices.size(),
+	        sg.normalIndices.data(), sg.normalIndices.size(),
 
 	        puvs.first.data(), puvs.second.data(), puvCounts.first.data(), puvCounts.second.data(),
 	        puvIndices.first.data(), puvIndices.second.data(), static_cast<uint32_t>(sg.uvs.size()),

--- a/src/codec/encoder/HoudiniEncoder.cpp
+++ b/src/codec/encoder/HoudiniEncoder.cpp
@@ -59,7 +59,7 @@ const prtx::EncodePreparator::PreparationFlags PREP_FLAGS =
                 .cleanupVertexNormals(true)
                 .cleanupUVs(true)
                 .processVertexNormals(prtx::VertexNormalProcessor::SET_MISSING_TO_FACE_NORMALS)
-                .indexSharing(prtx::EncodePreparator::PreparationFlags::INDICES_SAME_FOR_ALL_VERTEX_ATTRIBUTES);
+                .indexSharing(prtx::EncodePreparator::PreparationFlags::INDICES_SEPARATE_FOR_ALL_VERTEX_ATTRIBUTES);
 
 std::vector<const wchar_t*> toPtrVec(const prtx::WStringVector& wsv) {
 	std::vector<const wchar_t*> pw(wsv.size());

--- a/src/codec/encoder/HoudiniEncoder.h
+++ b/src/codec/encoder/HoudiniEncoder.h
@@ -40,21 +40,23 @@ namespace detail {
 
 struct SerializedGeometry {
 	prtx::DoubleVector coords;
-	prtx::DoubleVector normals; // uses same indexing as coords
+	prtx::DoubleVector normals;
 	std::vector<uint32_t> counts;
-	std::vector<uint32_t> indices;
+	std::vector<uint32_t> vertexIndices;
+	std::vector<uint32_t> normalIndices;
 
 	std::vector<prtx::DoubleVector> uvs;
 	std::vector<prtx::IndexVector> uvCounts;
 	std::vector<prtx::IndexVector> uvIndices;
 
 	SerializedGeometry(uint32_t numCoords, uint32_t numNormalCoords, uint32_t numCounts, uint32_t numIndices,
-	                   uint32_t uvSets)
+	                   uint32_t numNormalIndices, uint32_t uvSets)
 	    : uvs(uvSets), uvCounts(uvSets), uvIndices(uvSets) {
 		coords.reserve(3 * numCoords);
 		normals.reserve(3 * numNormalCoords);
 		counts.reserve(numCounts);
-		indices.reserve(numIndices);
+		vertexIndices.reserve(numIndices);
+		normalIndices.reserve(numIndices);
 	}
 };
 

--- a/src/palladio/ModelConverter.h
+++ b/src/palladio/ModelConverter.h
@@ -61,11 +61,11 @@ public:
 
 protected:
 	void add(const wchar_t* name, const double* vtx, size_t vtxSize, const double* nrm, size_t nrmSize,
-	         const uint32_t* counts, size_t countsSize, const uint32_t* indices, size_t indicesSize,
-	         double const* const* uvs, size_t const* uvsSizes, uint32_t const* const* uvCounts,
-	         size_t const* uvCountsSizes, uint32_t const* const* uvIndices, size_t const* uvIndicesSizes,
-	         uint32_t uvSets, const uint32_t* faceRanges, size_t faceRangesSize, const prt::AttributeMap** materials,
-	         const prt::AttributeMap** reports, const int32_t* shapeIDs) override;
+	         const uint32_t* counts, size_t countsSize, const uint32_t* vertexIndices, size_t vertexIndicesSize,
+	         const uint32_t* normalIndices, size_t normalIndicesSize, double const* const* uvs, size_t const* uvsSizes,
+	         uint32_t const* const* uvCounts, size_t const* uvCountsSizes, uint32_t const* const* uvIndices,
+	         size_t const* uvIndicesSizes, uint32_t uvSets, const uint32_t* faceRanges, size_t faceRangesSize,
+	         const prt::AttributeMap** materials, const prt::AttributeMap** reports, const int32_t* shapeIDs) override;
 
 	prt::Status generateError(size_t isIndex, prt::Status status, const wchar_t* message) override;
 	prt::Status assetError(size_t isIndex, prt::CGAErrorLevel level, const wchar_t* key, const wchar_t* uri,


### PR DESCRIPTION
Use separate indices for all vertex attributes (i.e. avoid duplicate vertices for different facenormals)