### PR TITLE
Bug fix: filter common illegal characters out of HDA name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ import com.esri.zrh.jenkins.psl.UploadTrackingPsl
 	DOCKER_IMAGE_LINUX_CONFIG + [ os: CEPL.CFG_OS_RHEL8, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_GCC112, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.0' ],
 	[ os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1437, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.0' ],
 	DOCKER_IMAGE_LINUX_CONFIG + [ grp: 'cesdkLatest', os: CEPL.CFG_OS_RHEL8, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_GCC112, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.0', cesdk: PAPL.Dependencies.CESDK_LATEST ],
-	[ grp: 'cesdkLatest', os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1437, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.0', cesdk: PAPL.Dependencies.CESDK_LATEST ],
+	[ grp: 'cesdkLatest', os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1438, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.0', cesdk: PAPL.Dependencies.CESDK_LATEST ],
 ]
 
 

--- a/src/palladio/ResolveMapCache.cpp
+++ b/src/palladio/ResolveMapCache.cpp
@@ -23,6 +23,7 @@
 #endif
 
 #include <fstream>
+#include <string_view>
 
 namespace {
 
@@ -69,6 +70,8 @@ ResolveMapCache::KeyType createCacheKey(const std::filesystem::path& rpk) {
 }
 
 #ifndef PLD_TEST_EXPORTS
+constexpr std::string_view ILLEGAL_FS_CHARS = "\\/:*?\"<>|";
+
 std::filesystem::path resolveFromHDA(const std::filesystem::path& p, const std::filesystem::path& unpackPath) {
 	LOG_DBG << "detected embedded resource in HDA: " << p;
 
@@ -77,7 +80,8 @@ std::filesystem::path resolveFromHDA(const std::filesystem::path& p, const std::
 	LOG_DBG << "resource container: " << container;
 
 	auto resName = p.filename().string();
-	std::replace(resName.begin(), resName.end(), '?', '_'); // TODO: generalize
+	std::replace_if(resName.begin(), resName.end(), [](char c) {
+		return (ILLEGAL_FS_CHARS.find(c) != std::string::npos); },'_');
 	std::filesystem::path extractedResource = unpackPath / resName;
 
 	if (fsr.isGood()) {

--- a/src/palladio/ResolveMapCache.cpp
+++ b/src/palladio/ResolveMapCache.cpp
@@ -70,8 +70,6 @@ ResolveMapCache::KeyType createCacheKey(const std::filesystem::path& rpk) {
 }
 
 #ifndef PLD_TEST_EXPORTS
-constexpr std::string_view ILLEGAL_FS_CHARS = "\\/:*?\"<>|";
-
 std::filesystem::path resolveFromHDA(const std::filesystem::path& p, const std::filesystem::path& unpackPath) {
 	LOG_DBG << "detected embedded resource in HDA: " << p;
 
@@ -79,10 +77,8 @@ std::filesystem::path resolveFromHDA(const std::filesystem::path& p, const std::
 	UT_StringHolder container = getFSReaderFilename(fsr);
 	LOG_DBG << "resource container: " << container;
 
-	auto resName = p.filename().string();
-	std::replace_if(resName.begin(), resName.end(), [](char c) {
-		return (ILLEGAL_FS_CHARS.find(c) != std::string::npos); },'_');
-	std::filesystem::path extractedResource = unpackPath / resName;
+	std::filesystem::path extractedResource = unpackPath / p.filename();
+	ensureNonExistingFile(extractedResource);
 
 	if (fsr.isGood()) {
 		std::filesystem::create_directories(unpackPath);

--- a/src/palladio/Utils.cpp
+++ b/src/palladio/Utils.cpp
@@ -45,6 +45,8 @@
 
 namespace {
 
+constexpr std::string_view ILLEGAL_FS_CHARS = "\\/:*?\"<>|";
+
 template <typename inC, typename outC, typename FUNC>
 std::basic_string<outC> callAPI(FUNC f, const std::basic_string<inC>& s) {
 	std::vector<outC> buffer(s.size());
@@ -345,4 +347,13 @@ std::wstring getFileExtensionString(const std::vector<std::wstring>& extensions)
 	if (extensionString.empty())
 		return FILE_ANY;
 	return extensionString;
+}
+
+void ensureNonExistingFile(std::filesystem::path& p) {
+	std::string stem = p.stem().generic_string();
+
+	// filter out common illegal characters from the stem
+	std::replace_if(
+	        stem.begin(), stem.end(), [](char c) { return (ILLEGAL_FS_CHARS.find(c) != std::string::npos); }, '_');
+	p = p.parent_path() / (stem + p.extension().generic_string());
 }

--- a/src/palladio/Utils.cpp
+++ b/src/palladio/Utils.cpp
@@ -356,4 +356,9 @@ void ensureNonExistingFile(std::filesystem::path& p) {
 	std::replace_if(
 	        stem.begin(), stem.end(), [](char c) { return (ILLEGAL_FS_CHARS.find(c) != std::string::npos); }, '_');
 	p = p.parent_path() / (stem + p.extension().generic_string());
+
+	// ensure we do not produce a collision with existing file
+	for (size_t suf = 0; std::filesystem::exists(p); suf++) {
+		p = p.parent_path() / (stem + '_' + std::to_string(suf) + p.extension().generic_string());
+	}
 }

--- a/src/palladio/Utils.h
+++ b/src/palladio/Utils.h
@@ -109,4 +109,4 @@ inline bool startsWithAnyOf(const std::string& s, const std::vector<std::string>
 }
 
 PLD_TEST_EXPORTS_API std::wstring getFileExtensionString(const std::vector<std::wstring>& extensions);
-void ensureNonExistingFile(std::filesystem::path& p);
+PLD_TEST_EXPORTS_API void ensureNonExistingFile(std::filesystem::path& p);

--- a/src/palladio/Utils.h
+++ b/src/palladio/Utils.h
@@ -109,3 +109,4 @@ inline bool startsWithAnyOf(const std::string& s, const std::vector<std::string>
 }
 
 PLD_TEST_EXPORTS_API std::wstring getFileExtensionString(const std::vector<std::wstring>& extensions);
+void ensureNonExistingFile(std::filesystem::path& p);

--- a/src/test/tests.cpp
+++ b/src/test/tests.cpp
@@ -241,6 +241,58 @@ TEST_CASE("create file extension string", "[utils]") {
 	}
 }
 
+TEST_CASE("legalize file stem and ensure it does not exist") {
+	auto const base = std::filesystem::temp_directory_path() / std::tmpnam(nullptr);
+	REQUIRE(!std::filesystem::exists(base));
+	std::filesystem::create_directories(base);
+
+	SECTION("default case") {
+		std::filesystem::path p = base / "foo.bar";
+		ensureNonExistingFile(p);
+		CHECK(p == base / "foo.bar");
+	}
+
+	SECTION("default case without extension") {
+		std::filesystem::path p = base / "foo";
+		ensureNonExistingFile(p);
+		CHECK(p == base / "foo");
+	}
+
+	SECTION("existing file") {
+		std::filesystem::path p = base / "foo.bar";
+		std::ofstream out(p);
+		REQUIRE(std::filesystem::exists(p));
+		ensureNonExistingFile(p);
+		CHECK(p == base / "foo_0.bar");
+	}
+
+	SECTION("existing file without extension") {
+		std::filesystem::path p = base / "foo";
+		std::ofstream out(p);
+		REQUIRE(std::filesystem::exists(p));
+		ensureNonExistingFile(p);
+		CHECK(p == base / "foo_0");
+	}
+
+	SECTION("existing file with suffix") {
+		std::filesystem::path p = base / "foo_0.bar";
+		std::ofstream out(p);
+		REQUIRE(std::filesystem::exists(p));
+		ensureNonExistingFile(p);
+		CHECK(p == base / "foo_0_0.bar");
+	}
+
+	SECTION("existing directory of same name") {
+		std::filesystem::path p = base / "foo.bar";
+		std::filesystem::create_directories(p);
+		REQUIRE(std::filesystem::exists(p));
+		ensureNonExistingFile(p);
+		CHECK(p == base / "foo_0.bar");
+	}
+
+	std::filesystem::remove_all(base);
+}
+
 // -- encoder test cases
 
 TEST_CASE("serialize basic mesh") {


### PR DESCRIPTION
This fixes cooking errors when an HDA internal name e.g. contains colons.