### PR TITLE
CI: switch Windows/msvc build steps to Docker-based toolchain

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,27 +26,28 @@ import com.esri.zrh.jenkins.psl.UploadTrackingPsl
 
 @Field final List CONFIGS_CHECKOUT = [ [ ba: PSL.BA_CHECKOUT ] ]
 @Field final Map DOCKER_IMAGE_LINUX_CONFIG = [ ba: PSL.BA_LINUX_DOCKER, containerId: "build_tools/ce-tc-prt:almalinux8-gcc11-v2", containerWorkspace: "/tmp/app" ]
+@Field final Map DOCKER_IMAGE_WINDOWS_CONFIG = [ ba: 'win19-64-d', containerId: 'palladio/palladio-tc:win19-vc1437-v0', containerWorkspace: 'c:/tmp/work' ]
 
 @Field final List CONFIGS_TEST = [
 	DOCKER_IMAGE_LINUX_CONFIG + [ os: CEPL.CFG_OS_RHEL8, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_GCC112, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64 ],
-	[ os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1437, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64 ],
+	DOCKER_IMAGE_WINDOWS_CONFIG + [ os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1437, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64 ],
 ]
 
 @Field final List CONFIGS_HOUDINI_195 = [
 	DOCKER_IMAGE_LINUX_CONFIG + [ os: CEPL.CFG_OS_RHEL8, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_GCC112, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '19.5' ],
-	[ os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1437, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '19.5' ],
+	DOCKER_IMAGE_WINDOWS_CONFIG + [ os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1437, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '19.5' ],
 ]
 
 @Field final List CONFIGS_HOUDINI_200 = [
 	DOCKER_IMAGE_LINUX_CONFIG + [ os: CEPL.CFG_OS_RHEL8, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_GCC112, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.0' ],
-	[ os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1437, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.0' ],
+	DOCKER_IMAGE_WINDOWS_CONFIG + [ os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1437, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.0' ],
 ]
 
 @Field final List CONFIGS_HOUDINI_205 = [
 	DOCKER_IMAGE_LINUX_CONFIG + [ os: CEPL.CFG_OS_RHEL8, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_GCC112, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.5' ],
-	[ os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1437, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.5' ],
+	DOCKER_IMAGE_WINDOWS_CONFIG + [ os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1437, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.5' ],
 	DOCKER_IMAGE_LINUX_CONFIG + [ grp: 'cesdkLatest', os: CEPL.CFG_OS_RHEL8, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_GCC112, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.5', cesdk: PAPL.Dependencies.CESDK_LATEST ],
-	[ grp: 'cesdkLatest', os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1438, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.5', cesdk: PAPL.Dependencies.CESDK_LATEST ],
+	DOCKER_IMAGE_WINDOWS_CONFIG + [ grp: 'cesdkLatest', os: CEPL.CFG_OS_WIN10, bc: CEPL.CFG_BC_REL, tc: CEPL.CFG_TC_VC1438, cc: CEPL.CFG_CC_OPT, arch: CEPL.CFG_ARCH_X86_64, houdini: '20.5', cesdk: PAPL.Dependencies.CESDK_LATEST ],
 ]
 
 
@@ -59,7 +60,7 @@ properties([ disableConcurrentBuilds() ])
 
 // -- PIPELINE
 
-stage('prepare'){
+stage('prepare') {
 	cepl.runParallel(taskGenCheckout())
 }
 
@@ -122,10 +123,7 @@ def taskBuildPalladio(cfg) {
 		[ key: 'PLD_HOUDINI_VERSION', val: cfg.houdini]
 	]
 
-	final String stdOut = buildPalladio(cfg, defs, BUILD_TARGET)
-	if(!papl.runsOnDocker(cfg)) {
-		scanAndPublishBuildIssues(cfg, stdOut)
-	}
+	buildPalladio(cfg, defs, BUILD_TARGET)
 
 	def versionExtractor = { p ->
 		def vers = (p =~ /.*palladio-(.*)\.hdn.*/)
@@ -139,32 +137,33 @@ def taskBuildPalladio(cfg) {
 }
 
 def buildPalladio(cfg, defs, target) {
-	if(cfg.os == CEPL.CFG_OS_RHEL8) {
-		Map dirMap = [ "${env.WORKSPACE}" : cfg.containerWorkspace ]
-		Map envMap = [ DEFAULT_UID: '$(id -u)', DEFAULT_GID: '$(id -g)', WORKSPACE: cfg.containerWorkspace ]
-		String src = "${cfg.containerWorkspace}/${SOURCE}";
-		String bld = "${cfg.containerWorkspace}/build";
+	final Map dirMap = [ "${env.WORKSPACE}" : cfg.containerWorkspace ]
+	final String src = "${cfg.containerWorkspace}/${SOURCE}";
+	final String bld = "${cfg.containerWorkspace}/build";
+	final Map envMap = [ WORKSPACE: cfg.containerWorkspace ]
+
+	String cmd = ''
+	if (cfg.os == CEPL.CFG_OS_RHEL8) {
+		envMap << [ DEFAULT_UID: '$(id -u)', DEFAULT_GID: '$(id -g)' ]
 
 		cmd = "cd ${src}"
-		cmd += "\npython3 -m ensurepip"
-		cmd += "\npython3 -m pip install --user pipenv"
-		cmd += "\npython3 -m pipenv install"
-		cmd += "\nPYVENV=\$(python3 -m pipenv --venv)"
-		cmd += "\ncd ${cfg.containerWorkspace}"
-		cmd += "\nsource \${PYVENV}/bin/activate"
-		cmd += "\nconan remote add --force --insert=0 zrh-conan ${psl.CONAN_REMOTE_URL}"
-
-		cmd += "\ncmake -G Ninja -DCMAKE_BUILD_TYPE=Release "
-		defs.each { d -> cmd += " -D${d.key}=${ (d.val instanceof Closure) ? d.val.call(cfg) : d.val }" }
-		cmd +=" -S ${src} -B ${bld}"
-
-		cmd += "\ncmake --build ${bld} --target ${target}"
-		String stdOut = psl.runDockerCmd(cfg.containerId, cfg.containerWorkspace, cmd, dirMap, envMap)
-		echo(stdOut)
-		return stdOut
-	} else {
-		return papl.runCMakeBuild(SOURCE, 'build', target, cfg, defs)
+		cmd += "&& python3 -m ensurepip"
+		cmd += "&& python3 -m pip install --user pipenv"
+		cmd += "&& python3 -m pipenv install"
+		cmd += "&& PYVENV=\$(python3 -m pipenv --venv)"
+		cmd += "&& cd ${cfg.containerWorkspace}"
+		cmd += "&& source \${PYVENV}/bin/activate"
+		cmd += "&& conan remote add --force --insert=0 zrh-conan ${psl.CONAN_REMOTE_URL} && "
 	}
+
+    cmd += "cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -S ${src} -B ${bld}"
+    defs.each { d ->
+        String val = (d.val instanceof Closure) ? d.val.call(cfg) : d.val
+        val = val.replace('%', '%%') // Windows: defer expansion of env vars to container run time
+        cmd += " -D${d.key}=${val}"
+    }
+	cmd += " && cmake --build ${bld} --target ${target}"
+	psl.runDockerCmd(cfg.containerId, cfg.containerWorkspace, cmd, dirMap, envMap)
 }
 
 def scanAndPublishBuildIssues(Map cfg, String consoleOut) {

--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -1,0 +1,21 @@
+# escape=`
+
+ARG BASE_IMAGE="python:3.12-windowsservercore-1809"
+
+FROM ${BASE_IMAGE}
+SHELL ["cmd", "/S", "/C"]
+
+# see https://learn.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2022
+ADD https://aka.ms/vs/17/release/vs_buildtools.exe C:/temp/vs_buildtools.exe
+RUN C:\temp\vs_buildtools.exe --quiet --wait --norestart --nocache ^ `
+    --installPath C:\BuildTools ^ `
+    --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended ^ `
+    --add Microsoft.VisualStudio.Component.VC.14.37.17.7.x86.x64 ^ `
+    || IF "%ERRORLEVEL%"=="3010" EXIT 0
+
+WORKDIR C:/tmp/work
+
+RUN python -m pip install --no-cache-dir --upgrade pip wheel "conan<2.0"
+RUN conan remote add zrh-conan http://zrh-conan.esri.com:8081/artifactory/api/conan/conan-local
+
+ENTRYPOINT [ "C:\\BuildTools\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x64", "-vcvars_ver=14.37", "&&" ]


### PR DESCRIPTION
Note: this step 1 of 2 to introduce self-contained Docker toolchain images with pre-populated Conan caches.
Here, we switch to Windows Docker toolchain images but still referencing the Esri internal Conan repository.