### PR TITLE
Ci updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,9 @@ import com.esri.zrh.jenkins.psl.UploadTrackingPsl
 
 // -- GLOBAL DEFINITIONS
 
-@Field final String REPO         = 'https://github.com/Esri/palladio.git'
-@Field final String SOURCE       = "palladio.git/src"
+@Field final String SOURCE_ROOT  = 'cityengine_for_houdini.git'
+@Field final String REPO         = "https://github.com/esri/${SOURCE_ROOT}"
+@Field final String SOURCE       = "${SOURCE_ROOT}/src"
 @Field final String BUILD_TARGET = 'package'
 @Field final String SOURCE_STASH = 'palladio-src'
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,9 +21,9 @@ set(HOUDINI_RELATIVE_PALLADIO_PATH "${HOUDINI_RELATIVE_PACKAGES_PATH}/palladio")
 ### versioning
 
 set(PLD_VERSION_MAJOR 2)
-set(PLD_VERSION_MINOR 3)
+set(PLD_VERSION_MINOR 4)
 set(PLD_VERSION_PATCH 0)
-set(PLD_VERSION_PRE "") # set to empty string for final releases
+set(PLD_VERSION_PRE "-dev.0") # set to empty string for final releases
 if (NOT PLD_VERSION_BUILD)
     set(PLD_VERSION_BUILD DEV)
 endif ()


### PR DESCRIPTION
The git URL change is just a cleanup for consistency with other CityEngine Plugins.